### PR TITLE
fix: context reset fix

### DIFF
--- a/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-new-message.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-new-message.component.tsx
@@ -88,7 +88,7 @@ export default function CaseNewMessage() {
 
     try {
       const res = await postMessageMutation.mutateAsync(formData);
-      if (!res.error) context.reset();
+      if (!res.error) context.resetField('message');
     } catch (error) {
       console.error('Error sending message:', error);
     }


### PR DESCRIPTION
- Now  we only reset the message area field instead of all context.
- This caused that the checkboxes under settings where shown as disable because of its default value.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).

Jira: https://jira.sundsvall.se/browse/DRAKEN-2240
