### PR TITLE
fix: handle opene attachments separately

### DIFF
--- a/backend/src/controllers/case.controller.ts
+++ b/backend/src/controllers/case.controller.ts
@@ -469,16 +469,15 @@ export class CaseController {
     let url: string;
     let headers: Record<string, string> = {};
     let data: MessageRequest | WebMessageRequest | MessagingWebMessageRequest | FormData;
-    if (_case.system === 'CASE_DATA') {
-      const conversationUrl = `${getApiBase('case-data')}/${MUNICIPALITY_ID}/${_case.namespace}/errands/${caseId}/communication/conversations`;
+
+    const buildMessageData = async (apiBase: string) => {
+      const conversationUrl = `${apiBase}/${MUNICIPALITY_ID}/${_case.namespace}/errands/${caseId}/communication/conversations`;
       const resConversation = await this.apiService.get<Conversation[]>({ url: conversationUrl }, req);
       let conversation: Conversation;
 
       const externalConversation = findExternalConversation(resConversation.data);
       if (!resConversation.data || resConversation.data.length === 0 || !externalConversation) {
-        const createConversationUrl = `${getApiBase('case-data')}/${MUNICIPALITY_ID}/${
-          _case.namespace
-        }/errands/${caseId}/communication/conversations`;
+        const createConversationUrl = `${apiBase}/${MUNICIPALITY_ID}/${_case.namespace}/errands/${caseId}/communication/conversations`;
         const createConversationdata = this.conversationInit(req.user);
         const resCreateConversation = await this.apiService.post({ data: createConversationdata, url: createConversationUrl }, req);
 
@@ -495,9 +494,7 @@ export class CaseController {
       } else {
         conversation = externalConversation;
       }
-      url = `${getApiBase('case-data')}/${MUNICIPALITY_ID}/${_case.namespace}/errands/${caseId}/communication/conversations/${
-        conversation.id
-      }/messages`;
+      url = `${apiBase}/${MUNICIPALITY_ID}/${_case.namespace}/errands/${caseId}/communication/conversations/${conversation.id}/messages`;
       headers = {
         'Content-Type': 'multipart/form-data',
       };
@@ -513,49 +510,15 @@ export class CaseController {
           formData.append('attachments', new Blob([file.buffer], { type: file.mimetype }), file.originalname);
         });
       }
-      data = formData;
+      return formData;
+    };
+
+    if (_case.system === 'CASE_DATA') {
+      const apiBase = getApiBase('case-data');
+      data = await buildMessageData(apiBase);
     } else if (_case.system === 'SUPPORT_MANAGEMENT') {
-      const conversationUrl = `${getApiBase('supportmanagement')}/${MUNICIPALITY_ID}/${
-        _case.namespace
-      }/errands/${caseId}/communication/conversations`;
-      const resConversation = await this.apiService.get<Conversation[]>({ url: conversationUrl }, req);
-      let conversation: Conversation;
-
-      const externalConversation = findExternalConversation(resConversation.data);
-      if (!resConversation.data || resConversation.data.length === 0 || !externalConversation) {
-        const createConversationUrl = `${getApiBase('supportmanagement')}/${MUNICIPALITY_ID}/${
-          _case.namespace
-        }/errands/${caseId}/communication/conversations`;
-        const createConversationdata = this.conversationInit(req.user);
-        const resCreateConversation = await this.apiService.post({ data: createConversationdata, url: createConversationUrl }, req);
-
-        if (resCreateConversation.message === 'success') {
-          const resConversation = await this.apiService.get<Conversation[]>({ url: conversationUrl }, req);
-          conversation = findExternalConversation(resConversation.data);
-        }
-      } else {
-        conversation = externalConversation;
-      }
-      url = `${getApiBase('supportmanagement')}/${MUNICIPALITY_ID}/${_case.namespace}/errands/${caseId}/communication/conversations/${
-        conversation.id
-      }/messages`;
-
-      headers = {
-        'Content-Type': 'multipart/form-data',
-      };
-
-      const messageData = {
-        content: body.message,
-      };
-
-      const formData = new FormData();
-      formData.append('message', JSON.stringify(messageData));
-      if (files && files.length > 0) {
-        files.forEach(file => {
-          formData.append('attachments', new Blob([file.buffer], { type: file.mimetype }), file.originalname);
-        });
-      }
-      data = formData;
+      const apiBase = getApiBase('supportmanagement');
+      data = await buildMessageData(apiBase);
     } else if (_case.system === 'OPEN_E_PLATFORM') {
       url = `${getApiBase('messaging')}/${MUNICIPALITY_ID}/webmessage`;
       data = this.postMessageToMessagingMessage(req, caseId, body.message, files);

--- a/backend/src/controllers/case.controller.ts
+++ b/backend/src/controllers/case.controller.ts
@@ -196,19 +196,8 @@ export class CaseController {
       req.destroy();
     });
 
-    if (representing?.mode === RepresentingMode.BUSINESS) {
-      if (!representing?.BUSINESS) {
-        throw new HttpException(400, 'Bad Request');
-      }
-
-      const orgNumber = formatOrgNr(representing.BUSINESS.organizationNumber);
-
-      if (USE_CASES_CACHE && req.session.cache?.cases?.BUSINESS?.[orgNumber]) {
-        return { data: req.session.cache.cases.BUSINESS[orgNumber], message: 'success' };
-      }
-
+    const fetchCases = async (url: string) => {
       try {
-        const url = `${this.apiBase}/${MUNICIPALITY_ID}/${orgNumber}/statuses`;
         const res = await this.apiService.get<CaseStatusResponse[]>({ url, signal }, req);
         if (!res.data) {
           throw new HttpException(500, 'No data from API');
@@ -225,30 +214,27 @@ export class CaseController {
           return { data: [], message: 'error' };
         }
       }
+    };
+    let url;
+
+    if (representing?.mode === RepresentingMode.BUSINESS) {
+      if (!representing?.BUSINESS) {
+        throw new HttpException(400, 'Bad Request');
+      }
+      const orgNumber = formatOrgNr(representing.BUSINESS.organizationNumber);
+      if (USE_CASES_CACHE && req.session.cache?.cases?.BUSINESS?.[orgNumber]) {
+        return { data: req.session.cache.cases.BUSINESS[orgNumber], message: 'success' };
+      }
+
+      url = `${this.apiBase}/${MUNICIPALITY_ID}/${orgNumber}/statuses`;
     } else {
       if (USE_CASES_CACHE && req.session.cache?.cases?.PRIVATE) {
         return { data: req.session.cache.cases.PRIVATE, message: 'success' };
       }
 
-      try {
-        const url = `${this.apiBase}/${MUNICIPALITY_ID}/party/${req.user.partyId}/statuses`;
-        const res = await this.apiService.get<CaseStatusResponse[]>({ url, signal }, req);
-        if (!res.data) {
-          throw new HttpException(500, 'No data from API');
-        }
-        const cases = res.data.filter(caseIsallowed);
-        this.setCasesCache(req, cases);
-
-        return { data: cases, message: 'success' };
-      } catch (error) {
-        if (error.status === 404) {
-          this.setCasesCache(req, []);
-          return { data: [], message: '404 from api, Assumed empty array' };
-        } else {
-          throw new HttpException(500, 'Something went wrong');
-        }
-      }
+      url = `${this.apiBase}/${MUNICIPALITY_ID}/party/${req.user.partyId}/statuses`;
     }
+    return fetchCases(url);
   }
 
   @Get('/cases/:caseId')

--- a/backend/src/controllers/case.controller.ts
+++ b/backend/src/controllers/case.controller.ts
@@ -615,7 +615,7 @@ export class CaseController {
 
   // attachments
   @Get('/cases/:caseId/conversations/:conversationId/messages/:messageId/attachments/:attachmentId')
-  @OpenAPI({ summary: 'Return message attachment' })
+  @OpenAPI({ summary: 'Return message attachment for Casedata or Supportmanagement messages' })
   @UseBefore(authMiddleware)
   async getCaseMessageAttachment(
     @Req() req: RequestWithUser,
@@ -640,12 +640,42 @@ export class CaseController {
         url = `${getApiBase('supportmanagement')}/${MUNICIPALITY_ID}/${
           _case.namespace
         }/errands/${caseId}/communication/conversations/${conversationId}/messages/${messageId}/attachments/${attachmentId}`;
-      } else if (_case.system === 'OPEN_E_PLATFORM' || _case.system === 'BYGGR' || _case.system === 'ECOS') {
-        url = `${getApiBase('webmessagecollector')}/${MUNICIPALITY_ID}/messages/EXTERNAL/attachments/${attachmentId}`;
       } else {
         throw new HttpException(400, 'Bad request');
       }
 
+      const res = await this.apiService.get<string>({ url, responseType: 'arraybuffer', responseEncoding: 'base64' }, req);
+
+      if (!res.data) {
+        return { data: null, message: 'error' };
+      }
+
+      const base64 = Buffer.from(res.data).toString('base64');
+
+      return { data: base64, message: 'success' };
+    } catch (error) {
+      if (error.status === 404) {
+        // handle 404 as empty´
+        return { data: null, message: 'success' };
+      }
+      return { data: null, message: 'error' };
+    }
+  }
+
+  @Get('/cases/:caseId/messages/attachments/:attachmentId')
+  @OpenAPI({ summary: 'Return message attachment for OpenE, BYGGR or ECOS cases' })
+  @UseBefore(authMiddleware)
+  async getWebmessageAttachment(
+    @Req() req: RequestWithUser,
+    @Param('caseId') caseId: string,
+    @Param('attachmentId') attachmentId: string,
+  ): Promise<ApiResponse<string | null>> {
+    if (!caseId) {
+      throw new HttpException(400, 'Bad Request');
+    }
+
+    try {
+      const url = `${getApiBase('webmessagecollector')}/${MUNICIPALITY_ID}/messages/EXTERNAL/attachments/${attachmentId}`;
       const res = await this.apiService.get<string>({ url, responseType: 'arraybuffer', responseEncoding: 'base64' }, req);
 
       if (!res.data) {

--- a/backend/src/controllers/case.controller.ts
+++ b/backend/src/controllers/case.controller.ts
@@ -183,6 +183,26 @@ export class CaseController {
     };
   }
 
+  private fetchAttachment = async (url: string, req: RequestWithUser): Promise<ApiResponse<string | null>> => {
+    try {
+      const res = await this.apiService.get<string>({ url, responseType: 'arraybuffer', responseEncoding: 'base64' }, req);
+
+      if (!res.data) {
+        return { data: null, message: 'error' };
+      }
+
+      const base64 = Buffer.from(res.data).toString('base64');
+
+      return { data: base64, message: 'success' };
+    } catch (error) {
+      if (error.status === 404) {
+        // handle 404 as empty´
+        return { data: null, message: 'success' };
+      }
+      return { data: null, message: 'error' };
+    }
+  };
+
   @Get('/cases')
   @OpenAPI({ summary: 'Return a list of cases for current logged in user' })
   @UseBefore(authMiddleware)
@@ -507,7 +527,7 @@ export class CaseController {
       formData.append('message', JSON.stringify(messageData));
       if (files && files.length > 0) {
         files.forEach(file => {
-          formData.append('attachments', new Blob([file.buffer], { type: file.mimetype }), file.originalname);
+          formData.append('attachments', new Blob([file.buffer as BlobPart], { type: file.mimetype }), file.originalname);
         });
       }
       return formData;
@@ -579,36 +599,20 @@ export class CaseController {
 
     const _case = (await this.getCase(req, caseId)).data;
 
-    try {
-      let url: string;
-      if (_case.system === 'CASE_DATA') {
-        url = `${getApiBase('case-data')}/${MUNICIPALITY_ID}/${
-          _case.namespace
-        }/errands/${caseId}/communication/conversations/${conversationId}/messages/${messageId}/attachments/${attachmentId}`;
-      } else if (_case.system === 'SUPPORT_MANAGEMENT') {
-        url = `${getApiBase('supportmanagement')}/${MUNICIPALITY_ID}/${
-          _case.namespace
-        }/errands/${caseId}/communication/conversations/${conversationId}/messages/${messageId}/attachments/${attachmentId}`;
-      } else {
-        throw new HttpException(400, 'Bad request');
-      }
-
-      const res = await this.apiService.get<string>({ url, responseType: 'arraybuffer', responseEncoding: 'base64' }, req);
-
-      if (!res.data) {
-        return { data: null, message: 'error' };
-      }
-
-      const base64 = Buffer.from(res.data).toString('base64');
-
-      return { data: base64, message: 'success' };
-    } catch (error) {
-      if (error.status === 404) {
-        // handle 404 as empty´
-        return { data: null, message: 'success' };
-      }
-      return { data: null, message: 'error' };
+    let url: string;
+    if (_case.system === 'CASE_DATA') {
+      url = `${getApiBase('case-data')}/${MUNICIPALITY_ID}/${
+        _case.namespace
+      }/errands/${caseId}/communication/conversations/${conversationId}/messages/${messageId}/attachments/${attachmentId}`;
+    } else if (_case.system === 'SUPPORT_MANAGEMENT') {
+      url = `${getApiBase('supportmanagement')}/${MUNICIPALITY_ID}/${
+        _case.namespace
+      }/errands/${caseId}/communication/conversations/${conversationId}/messages/${messageId}/attachments/${attachmentId}`;
+    } else {
+      throw new HttpException(400, 'Bad request');
     }
+
+    return this.fetchAttachment(url, req);
   }
 
   @Get('/cases/:caseId/messages/attachments/:attachmentId')
@@ -623,23 +627,7 @@ export class CaseController {
       throw new HttpException(400, 'Bad Request');
     }
 
-    try {
-      const url = `${getApiBase('webmessagecollector')}/${MUNICIPALITY_ID}/messages/EXTERNAL/attachments/${attachmentId}`;
-      const res = await this.apiService.get<string>({ url, responseType: 'arraybuffer', responseEncoding: 'base64' }, req);
-
-      if (!res.data) {
-        return { data: null, message: 'error' };
-      }
-
-      const base64 = Buffer.from(res.data).toString('base64');
-
-      return { data: base64, message: 'success' };
-    } catch (error) {
-      if (error.status === 404) {
-        // handle 404 as empty´
-        return { data: null, message: 'success' };
-      }
-      return { data: null, message: 'error' };
-    }
+    const url = `${getApiBase('webmessagecollector')}/${MUNICIPALITY_ID}/messages/EXTERNAL/attachments/${attachmentId}`;
+    return this.fetchAttachment(url, req);
   }
 }

--- a/backend/src/controllers/case.controller.ts
+++ b/backend/src/controllers/case.controller.ts
@@ -183,7 +183,7 @@ export class CaseController {
     };
   }
 
-  private fetchAttachment = async (url: string, req: RequestWithUser): Promise<ApiResponse<string | null>> => {
+  private readonly fetchAttachment = async (url: string, req: RequestWithUser): Promise<ApiResponse<string | null>> => {
     try {
       const res = await this.apiService.get<string>({ url, responseType: 'arraybuffer', responseEncoding: 'base64' }, req);
 

--- a/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-message-files.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-message-files.component.tsx
@@ -12,7 +12,13 @@ export default function CaseMessageFiles(props: { message: FrontendMessageRespon
 
   const handleOpenFile = useCallback(
     (file: NonNullable<AttachmentResponse>) => async () => {
-      const url = `/cases/${caseData?.caseId}/conversations/${message.conversationId}/messages/${message.messageId}/attachments/${file.attachmentId}`;
+      if (!caseData) return;
+      let url;
+      if (caseData.system === 'OPEN_E_PLATFORM' || caseData.system === 'BYGGR' || caseData.system === 'ECOS') {
+        url = `/cases/${caseData?.caseId}/messages/attachments/${file.attachmentId}`;
+      } else {
+        url = `/cases/${caseData?.caseId}/conversations/${message.conversationId}/messages/${message.messageId}/attachments/${file.attachmentId}`;
+      }
 
       const attachment = await getCaseMessageAttachment(url); // returns base64 string
 


### PR DESCRIPTION
Bilagor på meddelande från openE, ByggR och Ecos måste hanteras separat, de hör inte till någon conversation.

Test kan göras på https://minasidor-test.sundsvall.se/privat/arenden/5301 med användare min02sid

Jämför med att köra denna PR:s branch lokalt när du försöker öppna pdfen som är 10Mb.

Jira https://jira.sundsvall.se/browse/DRAKEN-2314

Tillägg: har refaktorerat lite utifrån sonarcloud-förslag.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
