### PR TITLE
fix: adapt session settings after environment

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -215,9 +215,9 @@ class App {
         saveUninitialized: false,
         store: sessionStore,
         cookie: {
-          httpOnly: true,
+          httpOnly: this.env === 'production' && process.env.ENVIRONMENT !== 'TEST',
           sameSite: 'lax',
-          secure: this.env === 'production',
+          secure: this.env === 'production' && process.env.ENVIRONMENT !== 'TEST',
         },
       }),
     );


### PR DESCRIPTION
Justerar sessionsettings efter miljö så att testmiljön - där fake-idp ligger på naken ip-adress utan cert - tillåter inloggning/cookies

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
