### PR TITLE
feat(messages): visa ärendemeddelanden som chat-bubblor

### DIFF
--- a/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-message-files.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-message-files.component.tsx
@@ -2,14 +2,15 @@ import { AttachmentResponse } from '@data-contracts/backend/data-contracts';
 import { FrontendMessageResponse } from '@interfaces/case';
 import { getCaseMessageAttachment } from '@services/case-service';
 import { downloadBlob } from '@utils/download-blob';
-import { Button } from '@sk-web-gui/react';
-import { Download } from 'lucide-react';
-import { useCallback, useContext } from 'react';
+import { cx, Spinner } from '@sk-web-gui/react';
+import { Download, Paperclip } from 'lucide-react';
+import { useCallback, useContext, useState } from 'react';
 import { CaseContext } from '../case-layout.component';
 
-export default function CaseMessageFiles(props: { message: FrontendMessageResponse }) {
-  const { message } = props;
+export default function CaseMessageFiles(props: { message: FrontendMessageResponse; mine?: boolean }) {
+  const { message, mine } = props;
   const { caseData } = useContext(CaseContext);
+  const [downloadingId, setDownloadingId] = useState<string | undefined>(undefined);
 
   const handleOpenFile = useCallback(
     (file: NonNullable<AttachmentResponse>) => async () => {
@@ -24,28 +25,68 @@ export default function CaseMessageFiles(props: { message: FrontendMessageRespon
         url = `/cases/${caseData?.caseId}/conversations/${message.conversationId}/messages/${message.messageId}/attachments/${file.attachmentId}`;
       }
 
-      const attachment = await getCaseMessageAttachment(url); // returns base64 string
-      downloadBlob(attachment, file.contentType || 'application/octet-stream', file.name || 'download');
+      setDownloadingId(file.attachmentId);
+      try {
+        const attachment = await getCaseMessageAttachment(url); // returns base64 string
+        downloadBlob(attachment, file.contentType || 'application/octet-stream', file.name || 'download');
+      } finally {
+        setDownloadingId(undefined);
+      }
     },
     [caseData?.caseId, message.conversationId, message.messageId]
   );
 
-  if (!message || message.attachments?.length === 0) return null;
+  if (!message || !message.attachments?.length) return null;
+
+  const count = message.attachments.length;
 
   return (
-    <div className="flex gap-16 flex-col">
-      {message.attachments?.map((file, index) => {
-        return (
-          <Button
-            onClick={handleOpenFile(file)}
-            rightIcon={<Download className="ml-10" size={18} />}
-            className={'whitespace-normal break-all max-w-full'}
-            variant="link"
-            size="md"
-            key={`${index}`}
-          >{`${file.name}`}</Button>
-        );
-      })}
-    </div>
+    <section
+      className={cx(
+        'flex flex-col gap-10 rounded-12 border-1 p-12 shadow-sm',
+        mine
+          ? 'border-vattjom-background-300 bg-white text-[#222226] dark:border-divider dark:bg-background-content dark:text-body'
+          : 'border-divider bg-background-200 text-body dark:bg-background-content'
+      )}
+      aria-label="Bilagor"
+    >
+      <div className="flex items-center justify-between gap-12 text-small">
+        <div className="flex items-center gap-8 font-bold">
+          <span className="flex h-24 w-24 shrink-0 items-center justify-center rounded-full bg-vattjom-background-100 text-vattjom-surface-primary">
+            <Paperclip size={15} />
+          </span>
+          <span>Bilagor</span>
+        </div>
+        <span className={cx('shrink-0', mine ? 'text-[#51515c] dark:text-secondary' : 'text-secondary')}>
+          {count} {count === 1 ? 'fil' : 'filer'}
+        </span>
+      </div>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        {message.attachments.map((file, index) => {
+          const isDownloading = downloadingId === file.attachmentId;
+          return (
+            <button
+              key={`${index}`}
+              type="button"
+              disabled={isDownloading}
+              className={cx(
+                'flex w-full min-w-0 items-center gap-8 rounded-8 border-1 px-10 py-8 text-small transition disabled:opacity-60',
+                mine
+                  ? 'border-vattjom-background-300 bg-background-content text-[#222226] hover:bg-vattjom-background-100 dark:border-divider dark:bg-background-100 dark:text-body dark:hover:bg-background-200'
+                  : 'border-divider bg-background-content text-body hover:bg-background-100 dark:bg-background-100 dark:hover:brightness-110'
+              )}
+              onClick={handleOpenFile(file)}
+            >
+              <span className="min-w-0 flex-1 truncate text-left">{file.name}</span>
+              {isDownloading ? (
+                <Spinner size={2} className="shrink-0" />
+              ) : (
+                <Download size={18} className="shrink-0" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </section>
   );
 }

--- a/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-message.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-message.component.tsx
@@ -2,17 +2,37 @@ import { FrontendMessageResponse } from '@interfaces/case';
 import { User } from '@interfaces/user';
 import { useApi } from '@services/api-service';
 import sanitized from '@services/sanitizer-service';
-import { AvatarProps } from '@sk-web-gui/react';
+import { AvatarProps, cx, Label } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
+import localeSv from 'dayjs/locale/sv';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import { UserRound } from 'lucide-react';
 import { JSX } from 'react';
 import { MessageAvatar } from './case-message-avatar.component';
 import CaseMessageFiles from './case-message-files.component';
 import { SkSymbol } from './sk-symbol';
 
-export default function CaseMessage(props: { message: FrontendMessageResponse }) {
+dayjs.extend(relativeTime);
+// Register the locale as a VALUE — a bare `import 'dayjs/locale/sv'` can be tree-shaken,
+// which leaves fromNow() in English.
+dayjs.locale(localeSv);
+
+const formatAbsolute = (sent: string): string => dayjs(sent).format('YYYY-MM-DD, HH:mm');
+
+// Relative ("2 timmar sedan") while recent, absolute date once it is older than a week.
+const formatTimeLabel = (sent: string): string => {
+  const then = dayjs(sent);
+  return dayjs().diff(then, 'day') < 7 ? then.fromNow() : then.format('YYYY-MM-DD, HH:mm');
+};
+
+export default function CaseMessage(props: { message: FrontendMessageResponse; isLatest?: boolean }) {
   const { data: user } = useApi<User>({ url: '/me', method: 'get' });
-  const { message } = props;
+  const { message, isLatest } = props;
+
+  // Citizen's own messages (INBOUND) are "mine" → right/blue; handläggare (OUTBOUND) → left/neutral.
+  // This mirrors drakel's handläggare view, where the perspective is reversed.
+  const mine = message.direction === 'INBOUND';
+
   const sender =
     message.direction === 'OUTBOUND'
       ? `${message.sender} (Handläggare)`
@@ -28,86 +48,51 @@ export default function CaseMessage(props: { message: FrontendMessageResponse })
         }
       : { color: 'gronsta', logo: <UserRound size={21} /> };
 
-  // TODO: Uncomment when the API supports it
-  // const { caseData } = useContext(CaseContext);
-  // const putMessageIsViewed = useApi({
-  //   url: `/cases/${caseData?.caseId}/messages/${message.messageId}/viewed/true`,
-  //   method: 'put',
-  // });
-  // const messageRef = useRef<HTMLDivElement>(null);
-  // const hasTriggered = useRef(false);
-
-  // useEffect(() => {
-  //   const observer = new IntersectionObserver(
-  //     ([entry]) => {
-  //       if (
-  //         entry.isIntersecting &&
-  //         message.direction === 'OUTBOUND' &&
-  //         !messageIsViewed(message) &&
-  //         caseData?.caseId &&
-  //         !hasTriggered.current
-  //       ) {
-  //         hasTriggered.current = true;
-  //         putMessageIsViewed.mutateAsync({}).catch(() => {
-  //           console.error('Could not set message as viewed', message.messageId);
-  //         });
-  //       }
-  //     },
-  //     { threshold: 0.1 }
-  //   );
-
-  //   const currentMessageRef = messageRef.current;
-  //   if (currentMessageRef) {
-  //     observer.observe(currentMessageRef);
-  //   }
-
-  //   return () => {
-  //     if (currentMessageRef) {
-  //       observer.unobserve(currentMessageRef);
-  //     }
-  //   };
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [message.viewed, caseData?.caseId]);
-
   return (
-    <div /**ref={messageRef}**/ className="case-message flex flex-col gap-y-16 py-20 px-8">
-      <div className="case-message-header flex gap-16">
+    <article className={cx('case-message flex items-start gap-12 py-12 px-8', mine && 'flex-row-reverse')}>
+      <div className="shrink-0">
         <MessageAvatar color={avatarSettings.color} logo={avatarSettings.logo} />
-        <div className="flex items-center grow gap-16">
-          <div className="flex flex-col desktop:flex-row desktop:items-center grow desktop:gap-16">
-            <div className="text-large ellipsis">{sender}</div>
-            {message.sent ? (
-              <div className="text-small text-secondary">
-                <span className="sr-only">Skickat </span>
-                {`${dayjs(message.sent).format('YYYY-MM-DD, HH:mm')}`}
-              </div>
-            ) : null}
-          </div>
-          {/* TODO: Uncomment when the API supports it
-          {message.direction === 'OUTBOUND' && !messageIsViewed(message) ? (
-            <div className="flex justify-end grow">
-              <Label rounded color="vattjom" inverted>
-                Nytt
-              </Label>
-            </div>
-          ) : null} */}
+      </div>
+      <div className={cx('flex flex-col gap-y-4 min-w-0 max-w-[min(52rem,80%)]', mine ? 'items-end' : 'items-start')}>
+        <div className="flex flex-wrap items-center gap-x-8 gap-y-2 max-w-full px-2">
+          <span className="font-bold text-body text-small truncate">{sender}</span>
+          {message.sent ? (
+            <time dateTime={message.sent} title={formatAbsolute(message.sent)} className="text-small text-secondary">
+              <span className="sr-only">Skickat </span>
+              {formatTimeLabel(message.sent)}
+            </time>
+          ) : null}
+          {isLatest ? (
+            <Label rounded inverted color="vattjom" className="text-small">
+              Senaste
+            </Label>
+          ) : null}
+        </div>
+
+        {/* Mine (citizen) = blue bubble right; handläggare = neutral bubble left. */}
+        <div
+          className={cx(
+            'flex flex-col gap-y-14 rounded-16 border-1 px-16 py-14 max-w-full shadow-sm',
+            mine
+              ? 'border-vattjom-surface-primary bg-vattjom-surface-primary text-white dark:border-vattjom-background-300 dark:bg-vattjom-background-200 dark:text-vattjom-text-primary'
+              : 'border-divider bg-background-content text-body dark:bg-background-200'
+          )}
+        >
+          <span
+            className="text whitespace-pre-wrap break-words"
+            dangerouslySetInnerHTML={{
+              __html: sanitized(message.message?.replace(/\r\n/g, '<br>') || '')
+                // Normalize both <br> and <br/>
+                .replace(/<br\s*\/?>/gi, '<br/>')
+                // Remove all <br/>s before the first non-<br/> tag/content
+                .replace(/^(<br\/>\s*)+/i, '')
+                // Remove all <br/>s after the last non-<br/> tag/content
+                .replace(/(<br\/>\s*)+$/i, ''),
+            }}
+          />
+          <CaseMessageFiles message={message} mine={mine} />
         </div>
       </div>
-      <div className="flex flex-col gap-y-24">
-        <span
-          className="text"
-          dangerouslySetInnerHTML={{
-            __html: sanitized(message.message?.replace(/\r\n/g, '<br>') || '')
-              // Normalize both <br> and <br/>
-              .replace(/<br\s*\/?>/gi, '<br/>')
-              // Remove all <br/>s before the first non-<br/> tag/content
-              .replace(/^(<br\/>\s*)+/i, '')
-              // Remove all <br/>s after the last non-<br/> tag/content
-              .replace(/(<br\/>\s*)+$/i, ''),
-          }}
-        />
-        <CaseMessageFiles message={message} />
-      </div>
-    </div>
+    </article>
   );
 }

--- a/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-messages.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-messages.component.tsx
@@ -22,12 +22,11 @@ export default function CaseMessages() {
       </div>
       {caseMessages?.length ? (
         <>
-          <ul aria-label="Ärendemeddelanden" className="case-messages flex flex-col self-stretch gap-y-8">
+          <ul aria-label="Ärendemeddelanden" className="case-messages flex flex-col self-stretch gap-y-16">
             {caseMessages?.slice(0, visibleMessages).map((message, index) => {
               return (
-                <li key={index} className="flex flex-col gap-y-8">
-                  <CaseMessage message={message} />
-                  {index !== caseMessages.length - 1 ? <Divider className="m-0" /> : null}
+                <li key={index} className="flex flex-col">
+                  <CaseMessage message={message} isLatest={index === caseMessages.length - 1} />
                 </li>
               );
             })}


### PR DESCRIPTION
## Vad

Gör meddelandevyn i "Mina sidor" tydlig à la Teams/iMessage — man ser direkt vilka meddelanden som är **mina** och vilka som är **handläggarens**. Inspirerat av [drakel#6](https://github.com/Sundsvallskommun/web-app-drakel/pull/6), men perspektivet är **speglat** för medborgarvyn:

- **Mina (INBOUND, "Jag")** ligger till höger i en blå bubbla; **handläggarens (OUTBOUND)** till vänster i en neutral bubbla. Avataren sitter på avsändarens sida.
- Meta-rad ovanför bubblan: namn · svensk relativ tid · "Senaste".
- Bilagor får en stylad sektion per sida med fil-räknare och nedladdnings-spinner; läsbara även på den blå bubblan.
- Sanerad HTML-body behålls. Endast semantiska tokens → fungerar i ljust och mörkt.

## Omfattning

Endast meddelande-renderingen i `cases/case/meddelanden/`:
- `case-message.component.tsx` – bubbel-layout, relativ tid, "Senaste".
- `case-message-files.component.tsx` – stylad bilage-sektion per sida (nedladdningslogik per case-system orörd).
- `case-messages.component.tsx` – skickar `isLatest`, tar bort dividers mellan bubblor.

Ingen backend- eller kontrakts­ändring. Stackad ovanpå `feature/economic-aid-application-scaffold` (#206).

## Medvetet utelämnat

Svara/citat/"Hoppa till" – kräver `inReplyToId` som inte finns i meddelande­kontraktet.

## Test

- Frontend: `tsc` grön; eslint rent på ändrade filer.