### PR TITLE
feat(theme): add light/dark/system colour scheme toggle

### DIFF
--- a/frontend/locales/sv/common.json
+++ b/frontend/locales/sv/common.json
@@ -33,6 +33,12 @@
     "title": "Du är nu utloggad",
     "loginAgain": "Logga in igen"
   },
+  "colorScheme": {
+    "title": "Färgläge",
+    "light": "Ljust",
+    "dark": "Mörkt",
+    "system": "System"
+  },
   "noRepresent": {
     "title": "Hoppsan, vi hittade inget företag som är registrerat på dig",
     "description": "När du loggar in gör vi en kontroll mot Bolagsverket och Skatteverket, men vi fick ingen träff på ditt personnummer.",

--- a/frontend/src/interfaces/localstorage.ts
+++ b/frontend/src/interfaces/localstorage.ts
@@ -1,0 +1,6 @@
+import { ColorSchemeMode } from '@sk-web-gui/react';
+
+export interface LocalStorage {
+  colorScheme: ColorSchemeMode;
+  setColorScheme: (color: ColorSchemeMode) => void;
+}

--- a/frontend/src/layouts/app/layout.component.tsx
+++ b/frontend/src/layouts/app/layout.component.tsx
@@ -3,6 +3,7 @@
 import { AppWrapper } from '@contexts/app.context';
 import { ConfirmationDialogContextProvider, GuiProvider, defaultTheme } from '@sk-web-gui/react';
 import { MatomoWrapper } from '@utils/matomo-wrapper';
+import { useLocalStorage } from '@utils/use-localstorage.hook';
 import dayjs from 'dayjs';
 import 'dayjs/locale/se';
 import updateLocale from 'dayjs/plugin/updateLocale';
@@ -36,10 +37,12 @@ dayjs.updateLocale('se', {
  const theme = {...defaultTheme, screens: {...defaultTheme.screens, 'desktop-min': '1024px'}};
 
 export default function MyAppLayout({ children }) {
+  const colorScheme = useLocalStorage((state) => state.colorScheme);
+
   return (
     <html lang={i18nConfig.defaultLocale}>
       <body>
-        <GuiProvider theme={theme}>
+        <GuiProvider theme={theme} colorScheme={colorScheme}>
           <ConfirmationDialogContextProvider>
             <AppWrapper>
               <LoginGuard>

--- a/frontend/src/layouts/mobile-menu/mobile-menu.component.tsx
+++ b/frontend/src/layouts/mobile-menu/mobile-menu.component.tsx
@@ -10,6 +10,7 @@ import { RepresentingMode } from '../../interfaces/app';
 import { getSwitchedRepresentingMode, newRepresentingModePathname } from '../../utils/representingModeRoute';
 import { useBannerMenuItems } from '../banner-menu/banner-menu-items';
 import { MyPagesBusinessSwitch } from '../site-menu/site-menu-items';
+import { ColorSchemeSelect } from '../user-menu/color-scheme-select.component';
 
 export const MobileMenu = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -96,6 +97,8 @@ export const MobileMenu = () => {
                 {t('common:eServices')}
               </Link>
             </Button>
+          <Divider className="m-0 grow-0" />
+          <ColorSchemeSelect />
         </Modal.Content>
         <Modal.Footer>
           <Button

--- a/frontend/src/layouts/user-menu/color-scheme-select.component.tsx
+++ b/frontend/src/layouts/user-menu/color-scheme-select.component.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ColorSchemeMode, RadioButton } from '@sk-web-gui/react';
+import { useLocalStorage } from '@utils/use-localstorage.hook';
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Light/dark/system colour scheme selector. The chosen mode is persisted in localStorage and fed to
+ * the GuiProvider in the app layout, so the whole app re-themes. Rendered in both the desktop user
+ * menu and the mobile menu.
+ */
+export const ColorSchemeSelect = () => {
+  const { t } = useTranslation('common');
+  const colorScheme = useLocalStorage((state) => state.colorScheme);
+  const setColorScheme = useLocalStorage((state) => state.setColorScheme);
+
+  const options = [
+    { value: ColorSchemeMode.Light, label: t('common:colorScheme.light'), icon: <Sun /> },
+    { value: ColorSchemeMode.Dark, label: t('common:colorScheme.dark'), icon: <Moon /> },
+    { value: ColorSchemeMode.System, label: t('common:colorScheme.system'), icon: <Monitor /> },
+  ];
+
+  return (
+    <fieldset className="flex flex-col gap-8 w-full border-0 p-0 m-0">
+      <legend className="text-small font-bold mb-8">{t('common:colorScheme.title')}</legend>
+      {options.map((option) => (
+        <RadioButton
+          key={option.value}
+          name="color-scheme"
+          value={option.value}
+          checked={colorScheme === option.value}
+          onChange={() => setColorScheme(option.value)}
+        >
+          <span className="inline-flex items-center gap-8">
+            {option.icon}
+            {option.label}
+          </span>
+        </RadioButton>
+      ))}
+    </fieldset>
+  );
+};

--- a/frontend/src/layouts/user-menu/user-menu.component.tsx
+++ b/frontend/src/layouts/user-menu/user-menu.component.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { RepresentingMode } from '../../interfaces/app';
 import { titleCase } from '../../utils/title-caser';
 import { useAppContext } from '../../contexts/app.context';
+import { ColorSchemeSelect } from './color-scheme-select.component';
 
 export const UserMenu = () => {
   const { t } = useTranslation('common');
@@ -48,6 +49,12 @@ export const UserMenu = () => {
                   {t('common:profile')}
                   <Icon icon={<ArrowRight />} />
                 </Button>
+              </PopupMenu.Item>
+              <Divider />
+              <PopupMenu.Item>
+                <div className="px-12 py-8 w-full" data-cy="user-menu-color-scheme">
+                  <ColorSchemeSelect />
+                </div>
               </PopupMenu.Item>
               <Divider />
               <PopupMenu.Item>

--- a/frontend/src/utils/use-localstorage.hook.ts
+++ b/frontend/src/utils/use-localstorage.hook.ts
@@ -1,0 +1,21 @@
+import { LocalStorage } from '@interfaces/localstorage';
+import { ColorSchemeMode } from '@sk-web-gui/react';
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+/**
+ * Persisted client store for the chosen colour scheme. The value is read by the GuiProvider in the
+ * app layout, so changing it re-themes the whole app, and it survives reloads via localStorage.
+ */
+export const useLocalStorage = create(
+  persist<LocalStorage>(
+    (set) => ({
+      colorScheme: ColorSchemeMode.System,
+      setColorScheme: (colorScheme) => set(() => ({ colorScheme })),
+    }),
+    {
+      name: `${process.env.NEXT_PUBLIC_APP_NAME}-store`,
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);


### PR DESCRIPTION
## Vad

Lägger till en färglägesväljare (Ljust / Mörkt / System) i Mina sidor, som tidigare saknade dark/light mode helt.

- Valet sparas i localStorage via en zustand-store och matas in i rot-`GuiProvider` (`colorScheme`), så hela appen byter tema.
- Väljaren renderas både i **användarmenyn (desktop)** och i **mobilmenyn**, eftersom användarmenyn bara visas på desktop.
- Alla strängar ligger under `common`-namespacet (`colorScheme.*`).

## Filer

- `src/interfaces/localstorage.ts` *(ny)* – `LocalStorage`-interface
- `src/utils/use-localstorage.hook.ts` *(ny)* – persisterad zustand-store (default `System`)
- `src/layouts/user-menu/color-scheme-select.component.tsx` *(ny)* – själva väljaren
- `src/layouts/app/layout.component.tsx` – läser `colorScheme` och skickar till `GuiProvider`
- `src/layouts/user-menu/user-menu.component.tsx` – väljare i användarmenyn
- `src/layouts/mobile-menu/mobile-menu.component.tsx` – väljare i mobilmenyn
- `locales/sv/common.json` – i18n-nycklar

## Verifiering

- `tsc` type-check, ESLint och Prettier (på ändrade/nya filer): rent
- Kört lokalt i webbläsare: mörkt läge ger `<html class="dark">` med mörk bakgrund/ljus text, ljust läge återställer – temat slår igenom i hela appen via `GuiProvider`.

> Obs: PR:en aktiverar växlingen och sk-web-guis adaptiva teman. Enskilda vyer kan behöva en visuell genomgång i mörkt läge (vissa `surface-primary`-tokens är inte dark-safe).