### PR TITLE
fix(frontend): produce deployable standalone image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -30,8 +30,9 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy everything as root-owned and read-only
-COPY --from=builder --chown=0:0 --chmod=555 /app/next.config.js ./
+# Copy everything as root-owned and read-only.
+# next.config.js is not copied: standalone output serializes the resolved config
+# into server.js, and evaluating the file here would require dev-only plugins.
 COPY --from=builder --chown=0:0 --chmod=555 /app/public ./public
 COPY --from=builder --chown=0:0 --chmod=444 /app/package.json ./
 COPY --from=builder --chown=0:0 --chmod=555 /app/.next/standalone ./

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -23,6 +23,7 @@ envalid.cleanEnv(process.env, {
 });
 
 module.exports = withBundleAnalyzer({
+  output: 'standalone',
   allowedDevOrigins: ['dev.test'],
   turbopack: {},
   images: {


### PR DESCRIPTION
## Varför

Frontendens Dockerfile kopierar `.next/standalone`, men Next-konfigurationen producerade inte den katalogen. Ett vanligt `next build` blev därför grönt samtidigt som den faktiska containerbyggnaden alltid stannade i runtime-steget.

## Ändring och nytta

- Aktiverar Nexts `output: 'standalone'`, vilket gör konfigurationen till kanonisk ägare av det format som Dockerfile redan förväntar sig.
- Gör produktionsimagen byggbar och möjliggör verklig containerverifiering av säkerhetsuppgraderingen av Next/Sharp.
- Ingen route, rendering eller användarfunktion ändras.
- Runtime-imagen kopierar inte längre `next.config.js`: standalone-outputen serialiserar in konfigurationen i `server.js`, och filen kunde ändå inte evalueras i imagen eftersom den kräver dev-only-pluginen bundle-analyzer. Verifierat med ny docker build + containerstart.

## Verifiering

- `docker build -t wabc-frontend-standalone-check frontend`
- Kontrollerat i den byggda imagen att processen kör som uid 1001.
- Kontrollerat att runtime-imagen innehåller de Next- och Sharp-versioner som bygget producerar.

## Risk och återställning

Låg risk. Standalone-output använder Nexts filspårning för att bara paketera runtime-filer. Återställning är att revert:a den enda konfigurationsraden, men då måste Dockerfile samtidigt ändras eftersom den annars refererar till en katalog som inte finns.

