### PR TITLE
fix(frontend): restore TLS validation for health checks

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -47,3 +47,7 @@ jobs:
 
       - name: Dead code (knip)
         run: yarn knip
+
+      - name: Frontend unit tests
+        if: matrix.package == 'frontend'
+        run: yarn jest:ci

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,8 +1,7 @@
 // babel
 module.exports = {
   roots: ['<rootDir>/'],
-  // No unit tests currently exist (the stale pages-router suites were removed in the
-  // app-router migration); keep the harness without failing CI until app-router tests are added.
+  // Keep CI green if a refactor temporarily leaves no matching test files.
   passWithNoTests: true,
   // "testTimeout": 15000,
   // Add more setup options before each test is run
@@ -11,12 +10,7 @@ module.exports = {
   collectCoverage: true,
   // on node 14.x coverage provider v8 offers good speed and more or less good report
   coverageProvider: 'v8',
-  collectCoverageFrom: [
-    '<rootDir>/services/**/*.{js,jsx,ts,tsx}',
-    '<rootDir>/pages/**/*.{js,jsx,ts,tsx}',
-    '<rootDir>/components/**/*.{js,jsx,ts,tsx}',
-    '!**/__unused__/**',
-  ],
+  collectCoverageFrom: ['<rootDir>/src/**/*.{js,jsx,ts,tsx}', '!<rootDir>/src/data-contracts/**'],
   moduleNameMapper: {
     // Handle CSS imports (with CSS modules)
     // https://jestjs.io/docs/webpack#mocking-css-modules

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -40,7 +40,7 @@ module.exports = {
     // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object
     '^.+\\.(js|jsx|ts|tsx)$': [
       'babel-jest',
-      { presets: ['next/babel'], plugins: ['@babel/plugin-proposal-private-methods'] },
+      { presets: ['next/babel'] },
     ],
     // Handle image imports
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "baseline-browser-mapping": "^2.11.1"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "cypress": "cypress open",
     "cypress:headless": "npx cypress run --e2e",
     "jest": "jest --watch",
+    "jest:ci": "jest --runInBand",
     "jest:coverage": "jest --coverage",
     "test": "concurrently \"yarn jest\" \"yarn cypress\"",
     "type-check": "next typegen && tsc --pretty --noEmit"

--- a/frontend/src/app/api/health/up/route.test.ts
+++ b/frontend/src/app/api/health/up/route.test.ts
@@ -1,6 +1,8 @@
 /// <reference types="jest" />
 
 import axios from 'axios';
+// tsconfig sets `types: ["cypress"]`, so the global `expect` resolves to Chai's
+// Assertion; import Jest's expect explicitly to get Jest matcher typings.
 import { expect } from '@jest/globals';
 import { headers } from 'next/headers';
 

--- a/frontend/src/app/api/health/up/route.test.ts
+++ b/frontend/src/app/api/health/up/route.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
 
 import axios from 'axios';
-import { expect as jestExpect } from '@jest/globals';
+import { expect } from '@jest/globals';
 import { headers } from 'next/headers';
 
 import { GET } from './route';
@@ -41,8 +41,8 @@ describe('GET /api/health/up', () => {
 
     const response = await GET();
 
-    jestExpect(mockedAxios.get).toHaveBeenCalledWith('http://localhost:3001/api/health/up');
-    jestExpect(response.status).toBe(200);
-    await jestExpect(response.json()).resolves.toEqual({ status: 'UP' });
+    expect(mockedAxios.get).toHaveBeenCalledWith('http://localhost:3001/api/health/up');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: 'UP' });
   });
 });

--- a/frontend/src/app/api/health/up/route.test.ts
+++ b/frontend/src/app/api/health/up/route.test.ts
@@ -1,0 +1,48 @@
+/// <reference types="jest" />
+
+import axios from 'axios';
+import { expect as jestExpect } from '@jest/globals';
+import { headers } from 'next/headers';
+
+import { GET } from './route';
+
+jest.mock('axios');
+jest.mock('next/headers', () => ({
+  headers: jest.fn(),
+}));
+jest.mock('next/server', () => ({
+  NextResponse: class {
+    readonly status: number;
+    private readonly body: string;
+
+    constructor(body: string, init: { status: number }) {
+      this.body = body;
+      this.status = init.status;
+    }
+
+    async json() {
+      return JSON.parse(this.body);
+    }
+  },
+}));
+
+const mockedAxios = jest.mocked(axios);
+const mockedHeaders = jest.mocked(headers);
+
+describe('GET /api/health/up', () => {
+  beforeEach(() => {
+    mockedHeaders.mockResolvedValue({
+      get: jest.fn().mockReturnValue(null),
+    } as unknown as Awaited<ReturnType<typeof headers>>);
+  });
+
+  it('uses the default TLS verification when checking the backend', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { status: 'UP' } });
+
+    const response = await GET();
+
+    jestExpect(mockedAxios.get).toHaveBeenCalledWith('http://localhost:3001/api/health/up');
+    jestExpect(response.status).toBe(200);
+    await jestExpect(response.json()).resolves.toEqual({ status: 'UP' });
+  });
+});

--- a/frontend/src/app/api/health/up/route.ts
+++ b/frontend/src/app/api/health/up/route.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import https from 'https';
 import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 
@@ -17,12 +16,7 @@ export const GET = async () => {
   }
 
   try {
-    const agent = new https.Agent({
-      rejectUnauthorized: false,
-    });
-    const health = await axios
-      .get(`${process.env.NEXT_PUBLIC_API_URL}/health/up`, { httpsAgent: agent })
-      .then((res) => res.data);
+    const health = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/health/up`).then((res) => res.data);
 
     return new NextResponse(JSON.stringify(health), { status: 200 });
   } catch (error) {


### PR DESCRIPTION
## Varför

Frontendens server-side health-route skapade en HTTPS-agent med `rejectUnauthorized: false`. Det gjorde att certifikat och värdnamn inte verifierades vid hälsokontrollen mot backend, vilket öppnar för man-in-the-middle även om anropet använder HTTPS.

## Ändring och nytta

- Tar bort den specialbyggda HTTPS-agenten och använder Nodes/Axios standardverifiering av TLS.
- Lägger till ett regressionstest som bevisar att backendanropet görs utan en TLS-bypass.
- Återaktiverar den befintliga, tidigare vilande Jest-harnessen för App Router-testet och kör frontendens enhetstest i ordinarie quality-CI.
- Använder Jest-`expect` explicit så att TypeScript inte blandar ihop det med Cypress/Chai och SonarCloud kan identifiera assertionerna.
- Tar bort en trasig, överflödig Babel-pluginreferens i Jest-konfigurationen, deklarerar den direkt använda Jest-globals-modulen och riktar coverage-insamlingen mot `src/` i stället för utdöda pages-router-kataloger.

Fördelen är att en felaktig eller utbytt backendidentitet får health-checken att misslyckas tydligt i stället för att accepteras, och regressionen verifieras nu vid varje PR.

## Verifiering

- `yarn jest:ci` (1/1).
- `yarn type-check`, `yarn lint`, `yarn knip`.
- `yarn build`.

## Risk och återställning

Avsedd beteendeförändring: miljöer med självsignerade eller felkonfigurerade certifikat blir unhealthy tills deras trust chain är korrekt. Det är säkerhetsvinsten, inte ett fel som ska döljas i kod. Tillfällig rollback kan göras med revert, men rekommenderad återställning är att installera korrekt CA/certifikat i miljön. Miljöer med intern CA pekar ut sin trust chain via `NODE_EXTRA_CA_CERTS` i frontendcontainern i stället för att återinföra TLS-bypassen i kod.

Dependency-refresh #246 bör mergas först; denna PR behöver därefter en liten rebase eftersom båda deklarerar frontendberoenden.

