### PR TITLE
fix(backend): bound multipart upload requests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -49,6 +49,7 @@
     "hpp": "^0.2.3",
     "memorystore": "^1.6.7",
     "morgan": "^1.10.0",
+    "multer": "^2.0.2",
     "passport": "^0.6.0",
     "qs": "^6.15.1",
     "reflect-metadata": "^0.1.13",

--- a/backend/src/middlewares/error.middleware.test.ts
+++ b/backend/src/middlewares/error.middleware.test.ts
@@ -1,0 +1,42 @@
+import { NextFunction, Request, Response } from 'express';
+import { MulterError } from 'multer';
+import { HttpException } from '@exceptions/HttpException';
+import errorMiddleware from './error.middleware';
+
+const createMocks = () => {
+  const req = { method: 'POST', path: '/api/cases/1/messages' } as Request;
+  const res = {} as Response;
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  const next = vi.fn() as unknown as NextFunction;
+  return { req, res, next };
+};
+
+describe('errorMiddleware', () => {
+  it('maps multer upload limit violations to 400', () => {
+    const { req, res, next } = createMocks();
+
+    errorMiddleware(new MulterError('LIMIT_FILE_COUNT', 'files'), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Too many files' });
+  });
+
+  it('keeps the status and message of an HttpException', () => {
+    const { req, res, next } = createMocks();
+
+    errorMiddleware(new HttpException(404, 'Case not found'), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Case not found' });
+  });
+
+  it('falls back to 500 for unknown errors', () => {
+    const { req, res, next } = createMocks();
+
+    errorMiddleware(new Error('boom') as HttpException, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ message: 'boom' });
+  });
+});

--- a/backend/src/middlewares/error.middleware.test.ts
+++ b/backend/src/middlewares/error.middleware.test.ts
@@ -14,27 +14,49 @@ const createMocks = () => {
 
 describe('errorMiddleware', () => {
   it.each([
-    ['LIMIT_FILE_COUNT', undefined, 'files', 'UPLOAD_TOO_MANY_FILES', 'Du kan bifoga högst 10 filer.'],
-    ['LIMIT_FILE_SIZE', 'files', 'files', 'UPLOAD_FILE_TOO_LARGE', 'En bifogad fil får vara högst 50 MB.'],
-    ['LIMIT_FIELD_COUNT', undefined, undefined, 'UPLOAD_TOO_MANY_FIELDS', 'Formuläret innehåller fler än 50 textfält.'],
-    ['LIMIT_FIELD_KEY', undefined, undefined, 'UPLOAD_FIELD_NAME_TOO_LONG', 'Ett formulärfält har ett för långt namn.'],
-    ['LIMIT_FIELD_VALUE', 'message', 'message', 'UPLOAD_FIELD_TOO_LARGE', 'Ett textfält får innehålla högst 1 MB.'],
-    [
-      'LIMIT_PART_COUNT',
-      undefined,
-      undefined,
-      'UPLOAD_TOO_MANY_PARTS',
-      'Formuläret får innehålla högst 60 textfält och filer sammanlagt.',
-    ],
-    ['LIMIT_UNEXPECTED_FILE', 'files', 'files', 'UPLOAD_UNEXPECTED_FILE', 'Den valda filen kan inte bifogas i det här fältet.'],
-  ] as const)('maps %s to a typed 400 response', (multerCode, errorField, responseField, code, message) => {
+    {
+      multerCode: 'LIMIT_FILE_COUNT',
+      errorField: undefined,
+      response: { code: 'UPLOAD_TOO_MANY_FILES', field: 'files', params: { max: 10 } },
+    },
+    {
+      multerCode: 'LIMIT_FILE_SIZE',
+      errorField: 'files',
+      response: { code: 'UPLOAD_FILE_TOO_LARGE', field: 'files', params: { max: 50 } },
+    },
+    {
+      multerCode: 'LIMIT_FIELD_COUNT',
+      errorField: undefined,
+      response: { code: 'UPLOAD_TOO_MANY_FIELDS', params: { max: 50 } },
+    },
+    {
+      multerCode: 'LIMIT_FIELD_KEY',
+      errorField: undefined,
+      response: { code: 'UPLOAD_FIELD_NAME_TOO_LONG', params: { max: 255 } },
+    },
+    {
+      multerCode: 'LIMIT_FIELD_VALUE',
+      errorField: 'message',
+      response: { code: 'UPLOAD_FIELD_TOO_LARGE', field: 'message', params: { max: 1 } },
+    },
+    {
+      multerCode: 'LIMIT_PART_COUNT',
+      errorField: undefined,
+      response: { code: 'UPLOAD_TOO_MANY_PARTS', params: { max: 60 } },
+    },
+    {
+      multerCode: 'LIMIT_UNEXPECTED_FILE',
+      errorField: 'files',
+      response: { code: 'UPLOAD_UNEXPECTED_FILE', field: 'files' },
+    },
+  ] as const)('maps $multerCode to a typed 400 response', ({ multerCode, errorField, response }) => {
     const { req, res, next } = createMocks();
     const error = new MulterError(multerCode, errorField);
 
     errorMiddleware(error, req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ code, ...(responseField ? { field: responseField } : {}), message });
+    expect(res.json).toHaveBeenCalledWith(response);
   });
 
   it('keeps the status and message of an HttpException', () => {

--- a/backend/src/middlewares/error.middleware.test.ts
+++ b/backend/src/middlewares/error.middleware.test.ts
@@ -13,13 +13,28 @@ const createMocks = () => {
 };
 
 describe('errorMiddleware', () => {
-  it('maps multer upload limit violations to 400', () => {
+  it.each([
+    ['LIMIT_FILE_COUNT', undefined, 'files', 'UPLOAD_TOO_MANY_FILES', 'Du kan bifoga högst 10 filer.'],
+    ['LIMIT_FILE_SIZE', 'files', 'files', 'UPLOAD_FILE_TOO_LARGE', 'En bifogad fil får vara högst 50 MB.'],
+    ['LIMIT_FIELD_COUNT', undefined, undefined, 'UPLOAD_TOO_MANY_FIELDS', 'Formuläret innehåller fler än 50 textfält.'],
+    ['LIMIT_FIELD_KEY', undefined, undefined, 'UPLOAD_FIELD_NAME_TOO_LONG', 'Ett formulärfält har ett för långt namn.'],
+    ['LIMIT_FIELD_VALUE', 'message', 'message', 'UPLOAD_FIELD_TOO_LARGE', 'Ett textfält får innehålla högst 1 MB.'],
+    [
+      'LIMIT_PART_COUNT',
+      undefined,
+      undefined,
+      'UPLOAD_TOO_MANY_PARTS',
+      'Formuläret får innehålla högst 60 textfält och filer sammanlagt.',
+    ],
+    ['LIMIT_UNEXPECTED_FILE', 'files', 'files', 'UPLOAD_UNEXPECTED_FILE', 'Den valda filen kan inte bifogas i det här fältet.'],
+  ] as const)('maps %s to a typed 400 response', (multerCode, errorField, responseField, code, message) => {
     const { req, res, next } = createMocks();
+    const error = new MulterError(multerCode, errorField);
 
-    errorMiddleware(new MulterError('LIMIT_FILE_COUNT', 'files'), req, res, next);
+    errorMiddleware(error, req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Too many files' });
+    expect(res.json).toHaveBeenCalledWith({ code, ...(responseField ? { field: responseField } : {}), message });
   });
 
   it('keeps the status and message of an HttpException', () => {

--- a/backend/src/middlewares/error.middleware.ts
+++ b/backend/src/middlewares/error.middleware.ts
@@ -8,7 +8,7 @@ const errorMiddleware = (error: HttpException | MulterError, req: Request, res: 
   try {
     const uploadError = error instanceof MulterError ? toFileUploadErrorResponse(error) : undefined;
     const status: number = error instanceof MulterError ? 400 : error.status || 500;
-    const message: string = uploadError?.message ?? error.message ?? 'Something went wrong';
+    const message: string = uploadError?.code ?? error.message ?? 'Something went wrong';
     const validationErrors = error instanceof MulterError ? undefined : error.errors;
     const errors: string =
       validationErrors && validationErrors.length > 0

--- a/backend/src/middlewares/error.middleware.ts
+++ b/backend/src/middlewares/error.middleware.ts
@@ -1,13 +1,19 @@
 import { NextFunction, Request, Response } from 'express';
+import { MulterError } from 'multer';
 import { HttpException } from '@exceptions/HttpException';
 import { logger } from '@utils/logger';
 
-const errorMiddleware = (error: HttpException, req: Request, res: Response, next: NextFunction) => {
+const errorMiddleware = (error: HttpException | MulterError, req: Request, res: Response, next: NextFunction) => {
   try {
-    const status: number = error.status || 500;
+    // A MulterError means the request violated an upload limit (file count,
+    // file size, parts); that is a client error, not a server fault.
+    const status: number = error instanceof MulterError ? 400 : error.status || 500;
     const message: string = error.message || 'Something went wrong';
+    const validationErrors = error instanceof MulterError ? undefined : error.errors;
     const errors: string =
-      error.errors?.length > 0 ? JSON.stringify(error.errors.map(error => ({ property: error.property, constraints: error.constraints }))) : '';
+      validationErrors && validationErrors.length > 0
+        ? JSON.stringify(validationErrors.map(error => ({ property: error.property, constraints: error.constraints })))
+        : '';
 
     // Strip CR/LF from user-controlled values to prevent log injection
     const strip = (value: string) => value.replace(/[\r\n]/g, '');

--- a/backend/src/middlewares/error.middleware.ts
+++ b/backend/src/middlewares/error.middleware.ts
@@ -2,13 +2,13 @@ import { NextFunction, Request, Response } from 'express';
 import { MulterError } from 'multer';
 import { HttpException } from '@exceptions/HttpException';
 import { logger } from '@utils/logger';
+import { toFileUploadErrorResponse } from '@utils/files/fileUploadError';
 
 const errorMiddleware = (error: HttpException | MulterError, req: Request, res: Response, next: NextFunction) => {
   try {
-    // A MulterError means the request violated an upload limit (file count,
-    // file size, parts); that is a client error, not a server fault.
+    const uploadError = error instanceof MulterError ? toFileUploadErrorResponse(error) : undefined;
     const status: number = error instanceof MulterError ? 400 : error.status || 500;
-    const message: string = error.message || 'Something went wrong';
+    const message: string = uploadError?.message ?? error.message ?? 'Something went wrong';
     const validationErrors = error instanceof MulterError ? undefined : error.errors;
     const errors: string =
       validationErrors && validationErrors.length > 0
@@ -20,7 +20,7 @@ const errorMiddleware = (error: HttpException | MulterError, req: Request, res: 
     const logLine = `[${strip(req.method)}] ${strip(req.path)} >> StatusCode:: ${status}, Message:: ${strip(message)}, Errors:: ${strip(errors)}`;
     console.error(logLine);
     logger.error(logLine);
-    res.status(status).json({ message });
+    res.status(status).json(uploadError ?? { message });
   } catch (error) {
     next(error);
   }

--- a/backend/src/utils/files/fileUploadError.ts
+++ b/backend/src/utils/files/fileUploadError.ts
@@ -1,0 +1,85 @@
+import { MulterError } from 'multer';
+import { fileUploadSettings } from './fileUploadSettings';
+
+const fileUploadErrorCodes = {
+  FILE_TOO_LARGE: 'UPLOAD_FILE_TOO_LARGE',
+  FIELD_NAME_MISSING: 'UPLOAD_FIELD_NAME_MISSING',
+  FIELD_NAME_TOO_LONG: 'UPLOAD_FIELD_NAME_TOO_LONG',
+  FIELD_TOO_LARGE: 'UPLOAD_FIELD_TOO_LARGE',
+  TOO_MANY_FIELDS: 'UPLOAD_TOO_MANY_FIELDS',
+  TOO_MANY_FILES: 'UPLOAD_TOO_MANY_FILES',
+  TOO_MANY_PARTS: 'UPLOAD_TOO_MANY_PARTS',
+  UNEXPECTED_FILE: 'UPLOAD_UNEXPECTED_FILE',
+} as const;
+
+type FileUploadErrorCode = (typeof fileUploadErrorCodes)[keyof typeof fileUploadErrorCodes];
+
+interface FileUploadErrorResponse {
+  code: FileUploadErrorCode;
+  field?: string;
+  message: string;
+}
+
+interface FileUploadErrorDetails {
+  code: FileUploadErrorCode;
+  defaultField?: string;
+  message: string;
+}
+
+type MulterRuntimeErrorCode = MulterError['code'] | 'MISSING_FIELD_NAME';
+
+const bytesPerMb = 1024 * 1024;
+const maxFieldSizeMb = fileUploadSettings.MAX_FIELD_SIZE_BYTES / bytesPerMb;
+const maxFileSizeMb = fileUploadSettings.MAX_FILE_SIZE_BYTES / bytesPerMb;
+const maxPartsPerRequest = fileUploadSettings.MAX_FILES_PER_REQUEST + fileUploadSettings.MAX_FIELDS_PER_REQUEST;
+
+const fileUploadErrors = {
+  LIMIT_FILE_COUNT: {
+    code: fileUploadErrorCodes.TOO_MANY_FILES,
+    defaultField: 'files',
+    message: `Du kan bifoga högst ${fileUploadSettings.MAX_FILES_PER_REQUEST} filer.`,
+  },
+  LIMIT_FILE_SIZE: {
+    code: fileUploadErrorCodes.FILE_TOO_LARGE,
+    defaultField: 'files',
+    message: `En bifogad fil får vara högst ${maxFileSizeMb} MB.`,
+  },
+  LIMIT_FIELD_COUNT: {
+    code: fileUploadErrorCodes.TOO_MANY_FIELDS,
+    message: `Formuläret innehåller fler än ${fileUploadSettings.MAX_FIELDS_PER_REQUEST} textfält.`,
+  },
+  LIMIT_FIELD_KEY: {
+    code: fileUploadErrorCodes.FIELD_NAME_TOO_LONG,
+    message: 'Ett formulärfält har ett för långt namn.',
+  },
+  LIMIT_FIELD_VALUE: {
+    code: fileUploadErrorCodes.FIELD_TOO_LARGE,
+    message: `Ett textfält får innehålla högst ${maxFieldSizeMb} MB.`,
+  },
+  LIMIT_PART_COUNT: {
+    code: fileUploadErrorCodes.TOO_MANY_PARTS,
+    message: `Formuläret får innehålla högst ${maxPartsPerRequest} textfält och filer sammanlagt.`,
+  },
+  LIMIT_UNEXPECTED_FILE: {
+    code: fileUploadErrorCodes.UNEXPECTED_FILE,
+    defaultField: 'files',
+    message: 'Den valda filen kan inte bifogas i det här fältet.',
+  },
+  MISSING_FIELD_NAME: {
+    code: fileUploadErrorCodes.FIELD_NAME_MISSING,
+    message: 'Ett formulärfält saknar namn.',
+  },
+} satisfies Record<MulterRuntimeErrorCode, FileUploadErrorDetails>;
+
+const unknownUploadError: FileUploadErrorDetails = {
+  code: fileUploadErrorCodes.UNEXPECTED_FILE,
+  message: 'Uppladdningen kunde inte behandlas.',
+};
+
+export const toFileUploadErrorResponse = (error: MulterError): FileUploadErrorResponse => {
+  const details: FileUploadErrorDetails = fileUploadErrors[error.code as MulterRuntimeErrorCode] ?? unknownUploadError;
+  const { defaultField, ...response } = details;
+  const field = error.field ?? defaultField;
+
+  return field ? { ...response, field } : response;
+};

--- a/backend/src/utils/files/fileUploadError.ts
+++ b/backend/src/utils/files/fileUploadError.ts
@@ -17,13 +17,17 @@ type FileUploadErrorCode = (typeof fileUploadErrorCodes)[keyof typeof fileUpload
 interface FileUploadErrorResponse {
   code: FileUploadErrorCode;
   field?: string;
-  message: string;
+  params?: FileUploadErrorParams;
 }
 
 interface FileUploadErrorDetails {
   code: FileUploadErrorCode;
   defaultField?: string;
-  message: string;
+  params?: FileUploadErrorParams;
+}
+
+interface FileUploadErrorParams {
+  max: number;
 }
 
 type MulterRuntimeErrorCode = MulterError['code'] | 'MISSING_FIELD_NAME';
@@ -37,43 +41,40 @@ const fileUploadErrors = {
   LIMIT_FILE_COUNT: {
     code: fileUploadErrorCodes.TOO_MANY_FILES,
     defaultField: 'files',
-    message: `Du kan bifoga högst ${fileUploadSettings.MAX_FILES_PER_REQUEST} filer.`,
+    params: { max: fileUploadSettings.MAX_FILES_PER_REQUEST },
   },
   LIMIT_FILE_SIZE: {
     code: fileUploadErrorCodes.FILE_TOO_LARGE,
     defaultField: 'files',
-    message: `En bifogad fil får vara högst ${maxFileSizeMb} MB.`,
+    params: { max: maxFileSizeMb },
   },
   LIMIT_FIELD_COUNT: {
     code: fileUploadErrorCodes.TOO_MANY_FIELDS,
-    message: `Formuläret innehåller fler än ${fileUploadSettings.MAX_FIELDS_PER_REQUEST} textfält.`,
+    params: { max: fileUploadSettings.MAX_FIELDS_PER_REQUEST },
   },
   LIMIT_FIELD_KEY: {
     code: fileUploadErrorCodes.FIELD_NAME_TOO_LONG,
-    message: 'Ett formulärfält har ett för långt namn.',
+    params: { max: fileUploadSettings.MAX_FIELD_NAME_LENGTH },
   },
   LIMIT_FIELD_VALUE: {
     code: fileUploadErrorCodes.FIELD_TOO_LARGE,
-    message: `Ett textfält får innehålla högst ${maxFieldSizeMb} MB.`,
+    params: { max: maxFieldSizeMb },
   },
   LIMIT_PART_COUNT: {
     code: fileUploadErrorCodes.TOO_MANY_PARTS,
-    message: `Formuläret får innehålla högst ${maxPartsPerRequest} textfält och filer sammanlagt.`,
+    params: { max: maxPartsPerRequest },
   },
   LIMIT_UNEXPECTED_FILE: {
     code: fileUploadErrorCodes.UNEXPECTED_FILE,
     defaultField: 'files',
-    message: 'Den valda filen kan inte bifogas i det här fältet.',
   },
   MISSING_FIELD_NAME: {
     code: fileUploadErrorCodes.FIELD_NAME_MISSING,
-    message: 'Ett formulärfält saknar namn.',
   },
 } satisfies Record<MulterRuntimeErrorCode, FileUploadErrorDetails>;
 
 const unknownUploadError: FileUploadErrorDetails = {
   code: fileUploadErrorCodes.UNEXPECTED_FILE,
-  message: 'Uppladdningen kunde inte behandlas.',
 };
 
 export const toFileUploadErrorResponse = (error: MulterError): FileUploadErrorResponse => {

--- a/backend/src/utils/files/fileUploadOptions.test.ts
+++ b/backend/src/utils/files/fileUploadOptions.test.ts
@@ -4,8 +4,8 @@ import { fileUploadSettings } from './fileUploadSettings';
 describe('fileUploadOptions', () => {
   it('bounds multipart request memory and parser work', () => {
     expect(fileUploadOptions.limits).toEqual({
-      fieldNameSize: 255,
-      fieldSize: 1024 * 1024,
+      fieldNameSize: fileUploadSettings.MAX_FIELD_NAME_LENGTH,
+      fieldSize: fileUploadSettings.MAX_FIELD_SIZE_BYTES,
       fileSize: fileUploadSettings.MAX_FILE_SIZE_BYTES,
       files: fileUploadSettings.MAX_FILES_PER_REQUEST,
       fields: fileUploadSettings.MAX_FIELDS_PER_REQUEST,

--- a/backend/src/utils/files/fileUploadOptions.test.ts
+++ b/backend/src/utils/files/fileUploadOptions.test.ts
@@ -1,0 +1,15 @@
+import { fileUploadOptions } from './fileUploadOptions';
+import { fileUploadSettings } from './fileUploadSettings';
+
+describe('fileUploadOptions', () => {
+  it('bounds multipart request memory and parser work', () => {
+    expect(fileUploadOptions.limits).toEqual({
+      fieldNameSize: 255,
+      fieldSize: 1024 * 1024,
+      fileSize: fileUploadSettings.MAX_FILE_SIZE_BYTES,
+      files: fileUploadSettings.MAX_FILES_PER_REQUEST,
+      fields: fileUploadSettings.MAX_FIELDS_PER_REQUEST,
+      parts: fileUploadSettings.MAX_FILES_PER_REQUEST + fileUploadSettings.MAX_FIELDS_PER_REQUEST,
+    });
+  });
+});

--- a/backend/src/utils/files/fileUploadOptions.ts
+++ b/backend/src/utils/files/fileUploadOptions.ts
@@ -16,7 +16,11 @@ const fileFilter = (_request: Request, file: Express.Multer.File, callback: Filt
 const uploadOptions = () => ({
   limits: {
     fieldNameSize: 255,
-    fileSize: 1024 * 1024 * 50, // 50mb
+    fieldSize: 1024 * 1024,
+    fileSize: fileUploadSettings.MAX_FILE_SIZE_BYTES,
+    files: fileUploadSettings.MAX_FILES_PER_REQUEST,
+    fields: fileUploadSettings.MAX_FIELDS_PER_REQUEST,
+    parts: fileUploadSettings.MAX_FILES_PER_REQUEST + fileUploadSettings.MAX_FIELDS_PER_REQUEST,
   },
   storage: multer.memoryStorage(),
   fileFilter,

--- a/backend/src/utils/files/fileUploadOptions.ts
+++ b/backend/src/utils/files/fileUploadOptions.ts
@@ -15,8 +15,8 @@ const fileFilter = (_request: Request, file: Express.Multer.File, callback: Filt
 
 const uploadOptions = () => ({
   limits: {
-    fieldNameSize: 255,
-    fieldSize: 1024 * 1024,
+    fieldNameSize: fileUploadSettings.MAX_FIELD_NAME_LENGTH,
+    fieldSize: fileUploadSettings.MAX_FIELD_SIZE_BYTES,
     fileSize: fileUploadSettings.MAX_FILE_SIZE_BYTES,
     files: fileUploadSettings.MAX_FILES_PER_REQUEST,
     fields: fileUploadSettings.MAX_FIELDS_PER_REQUEST,

--- a/backend/src/utils/files/fileUploadSettings.ts
+++ b/backend/src/utils/files/fileUploadSettings.ts
@@ -5,6 +5,8 @@ export const fileUploadSettings = {
   MAX_FILE_SIZE_BYTES: 1024 * 1024 * 50,
   MAX_FILES_PER_REQUEST: 10,
   MAX_FIELDS_PER_REQUEST: 50,
+  MAX_FIELD_NAME_LENGTH: 255,
+  MAX_FIELD_SIZE_BYTES: 1024 * 1024,
   fileNameFormat: (fileName: string) => {
     const fN = Date.now() + '-' + Math.round(Math.random() * 1e9);
     return fN + path.extname(fileName);

--- a/backend/src/utils/files/fileUploadSettings.ts
+++ b/backend/src/utils/files/fileUploadSettings.ts
@@ -2,6 +2,9 @@ import path from 'path';
 
 export const fileUploadSettings = {
   UPLOAD_FOLDER: 'uploads',
+  MAX_FILE_SIZE_BYTES: 1024 * 1024 * 50,
+  MAX_FILES_PER_REQUEST: 10,
+  MAX_FIELDS_PER_REQUEST: 50,
   fileNameFormat: (fileName: string) => {
     const fN = Date.now() + '-' + Math.round(Math.random() * 1e9);
     return fN + path.extname(fileName);

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -24,13 +24,16 @@ module.exports = {
     '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
 
     // Handle module aliases (this will be automatically configured for you soon)
-    '@components/(.*)$': '<rootDir>/components/$1',
-    '@interfaces/(.*)$': '<rootDir>/interfaces/$1',
-    '@utils/(.*)$': '<rootDir>/utils/$1',
-    '@pages/(.*)$': '<rootDir>/pages/$1',
+    '@app/(.*)$': '<rootDir>/src/app/$1',
+    '@components/(.*)$': '<rootDir>/src/components/$1',
+    '@contexts/(.*)$': '<rootDir>/src/contexts/$1',
+    '@data-contracts/(.*)$': '<rootDir>/src/data-contracts/$1',
+    '@interfaces/(.*)$': '<rootDir>/src/interfaces/$1',
+    '@layouts/(.*)$': '<rootDir>/src/layouts/$1',
+    '@pages/(.*)$': '<rootDir>/src/pages/$1',
     '@public/(.*)$': '<rootDir>/public/$1',
-    '@services/(.*)$': '<rootDir>/services/$1',
-    '@contexts/(.*)$': '<rootDir>/contexts/$1',
+    '@services/(.*)$': '<rootDir>/src/services/$1',
+    '@utils/(.*)$': '<rootDir>/src/utils/$1',
     '@jestRoot/(.*)$': '<rootDir>/.jest/$1',
   },
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/'],
@@ -40,7 +43,7 @@ module.exports = {
     // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object
     '^.+\\.(js|jsx|ts|tsx)$': [
       'babel-jest',
-      { presets: ['next/babel'], plugins: ['@babel/plugin-proposal-private-methods'] },
+      { presets: [['next/babel', { 'preset-react': { runtime: 'automatic' } }]] },
     ],
     // Handle image imports
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -3,7 +3,7 @@
   "entry": ["src/app/i18n.ts", "src/app/i18nConfig.ts", "cypress/**/*.{ts,tsx}", ".jest/**/*.{js,jsx,ts,tsx}"],
   "project": ["src/**/*.{ts,tsx}", "cypress/**/*.{ts,tsx}"],
   "ignore": ["src/data-contracts/**"],
-  "ignoreDependencies": ["sharp", "lint-staged", "@testing-library/dom", "@testing-library/react", "@testing-library/user-event", "react-test-renderer"],
+  "ignoreDependencies": ["sharp", "lint-staged", "@testing-library/user-event", "react-test-renderer"],
   "rules": {
     "enumMembers": "off"
   }

--- a/frontend/locales/sv/cases.json
+++ b/frontend/locales/sv/cases.json
@@ -10,5 +10,8 @@
     "title": "Avslutade",
     "empty": "Det finns inga avslutade ärenden",
     "loading": "Laddar avslutade ärenden"
+  },
+  "newMessage": {
+    "sendError": "Något gick fel när meddelandet skickades. Försök igen senare."
   }
 }

--- a/frontend/locales/sv/common.json
+++ b/frontend/locales/sv/common.json
@@ -57,5 +57,15 @@
   "seconds_one": "{{count}} sekund",
   "seconds_other": "{{count}} sekunder",
   "left": "kvar",
-  "citizenError": "Kunde inte hämta personuppgifter"
+  "citizenError": "Kunde inte hämta personuppgifter",
+  "uploadErrors": {
+    "UPLOAD_FILE_TOO_LARGE": "En bifogad fil får vara högst {{max}} MB.",
+    "UPLOAD_FIELD_NAME_MISSING": "Ett formulärfält saknar namn.",
+    "UPLOAD_FIELD_NAME_TOO_LONG": "Ett formulärfält får ha ett namn på högst {{max}} tecken.",
+    "UPLOAD_FIELD_TOO_LARGE": "Ett textfält får innehålla högst {{max}} MB.",
+    "UPLOAD_TOO_MANY_FIELDS": "Formuläret får innehålla högst {{max}} textfält.",
+    "UPLOAD_TOO_MANY_FILES": "Du kan bifoga högst {{max}} filer.",
+    "UPLOAD_TOO_MANY_PARTS": "Formuläret får innehålla högst {{max}} textfält och filer sammanlagt.",
+    "UPLOAD_UNEXPECTED_FILE": "Den valda filen kan inte bifogas i det här fältet."
+  }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "baseline-browser-mapping": "^2.11.1"
   },
   "devDependencies": {
+    "@jest/globals": "29.7.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-new-message.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-new-message.component.tsx
@@ -1,3 +1,4 @@
+import { applyApiErrorToForm } from '@services/form-api-error';
 import { useApi } from '@services/api-service';
 import {
   Button,
@@ -99,13 +100,14 @@ export default function CaseNewMessage() {
     }
 
     try {
-      const res = await postMessageMutation.mutateAsync(formData);
-      if (!res.error) context.reset();
+      await postMessageMutation.mutateAsync(formData);
+      context.reset();
     } catch (error) {
       console.error('Error sending message:', error);
-      context.setError('root', {
-        type: 'manual',
-        message: 'Något gick fel när meddelandet skickades, försök igen senare',
+      applyApiErrorToForm<NewMessage>(error, context, {
+        fallbackMessage: 'Något gick fel när meddelandet skickades, försök igen senare',
+        inlineFields: ['files', 'message'],
+        onFormError: (message) => context.setError('root', { message, type: 'server' }),
       });
     }
   };
@@ -113,7 +115,8 @@ export default function CaseNewMessage() {
   const handleRemoveFile = (file: UploadFile) => {
     context.setValue(
       'files',
-      context.watch('files').filter((x) => x !== file)
+      context.watch('files').filter((x) => x !== file),
+      { shouldValidate: true }
     );
   };
 

--- a/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-new-message.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-new-message.component.tsx
@@ -12,11 +12,12 @@ import {
   useThemeQueries,
 } from '@sk-web-gui/react';
 import { toBase64 } from '@utils/toBase64';
-import { validateFileCount } from '@utils/upload-limits';
+import { MAX_FILES_PER_UPLOAD, validateFileCount } from '@utils/upload-limits';
 import dayjs from 'dayjs';
 import { Info } from 'lucide-react';
 import { useContext, useMemo, useState } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { CaseContext } from '../case-layout.component';
 
 interface NewMessage {
@@ -27,6 +28,7 @@ interface NewMessage {
 const MESSAGE_CHARACTER_LIMIT = 10000;
 
 export default function CaseNewMessage() {
+  const { t } = useTranslation(['cases', 'common']);
   const { isMinDesktop } = useThemeQueries();
   const context = useForm<NewMessage>({ defaultValues: { files: [], message: '' }, mode: 'onChange' });
   const { caseData } = useContext(CaseContext);
@@ -105,9 +107,10 @@ export default function CaseNewMessage() {
     } catch (error) {
       console.error('Error sending message:', error);
       applyApiErrorToForm<NewMessage>(error, context, {
-        fallbackMessage: 'Något gick fel när meddelandet skickades, försök igen senare',
+        fallbackMessage: t('cases:newMessage.sendError'),
         inlineFields: ['files', 'message'],
         onFormError: (message) => context.setError('root', { message, type: 'server' }),
+        translate: t,
       });
     }
   };
@@ -153,7 +156,13 @@ export default function CaseNewMessage() {
                   appendFiles={files}
                   className="mt-16"
                   maxFileSizeMB={25}
-                  {...context.register('files', { validate: validateFileCount })}
+                  {...context.register('files', {
+                    validate: (files) =>
+                      validateFileCount(
+                        files,
+                        t('common:uploadErrors.UPLOAD_TOO_MANY_FILES', { max: MAX_FILES_PER_UPLOAD })
+                      ),
+                  })}
                 />
                 <div className="flex items-row text-small gap-5 mt-10">
                   <span className="text-dark-secondary">Maximal filstorlek: 25 MB.</span>{' '}

--- a/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-new-message.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/cases/case/meddelanden/case-new-message.component.tsx
@@ -11,6 +11,7 @@ import {
   useThemeQueries,
 } from '@sk-web-gui/react';
 import { toBase64 } from '@utils/toBase64';
+import { validateFileCount } from '@utils/upload-limits';
 import dayjs from 'dayjs';
 import { Info } from 'lucide-react';
 import { useContext, useMemo, useState } from 'react';
@@ -149,7 +150,7 @@ export default function CaseNewMessage() {
                   appendFiles={files}
                   className="mt-16"
                   maxFileSizeMB={25}
-                  {...context.register('files')}
+                  {...context.register('files', { validate: validateFileCount })}
                 />
                 <div className="flex items-row text-small gap-5 mt-10">
                   <span className="text-dark-secondary">Maximal filstorlek: 25 MB.</span>{' '}
@@ -157,6 +158,11 @@ export default function CaseNewMessage() {
                     Visa tillåtna filtyper
                   </Button>
                 </div>
+                {context.formState.errors.files && (
+                  <FormErrorMessage className="text-small text-error" role="alert">
+                    {context.formState.errors.files.message}
+                  </FormErrorMessage>
+                )}
               </div>
 
               {files.length ? (

--- a/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-file-upload.component.test.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-file-upload.component.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { ParkingPermitFileUpload } from './parkingpermit-file-upload.component';
+
+jest.mock('@sk-web-gui/react', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const Container = ({
+    children,
+    ...props
+  }: {
+    children?: import('react').ReactNode;
+    className?: string;
+    role?: string;
+  }) => React.createElement('div', props, children);
+
+  return {
+    FileUpload: {
+      Field: () => React.createElement('input', { type: 'file' }),
+      List: Container,
+      ListItem: Container,
+    },
+    FormErrorMessage: Container,
+  };
+});
+
+describe('ParkingPermitFileUpload', () => {
+  it('shows a file-specific server error next to the upload control', () => {
+    render(
+      <ParkingPermitFileUpload
+        category="POLICE_REPORT"
+        categoryLabel="Polisanmälan"
+        errorMessage="Du kan bifoga högst 10 filer."
+        files={[]}
+        maxFileSizeMB={25}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('alert').textContent?.trim()).toBe('Du kan bifoga högst 10 filer.');
+  });
+});

--- a/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-file-upload.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-file-upload.component.tsx
@@ -1,0 +1,58 @@
+import { FileUpload, FormErrorMessage, UploadFile } from '@sk-web-gui/react';
+import { ACCEPTED_UPLOAD_FILETYPES } from '@utils/accepted-file-types';
+
+type ParkingPermitFileCategory = 'MEDICAL_CONFIRMATION' | 'POLICE_REPORT';
+
+interface ParkingPermitFileUploadProps {
+  category: ParkingPermitFileCategory;
+  categoryLabel: string;
+  dataCy?: string;
+  errorMessage?: string;
+  files: UploadFile[];
+  maxFileSizeMB: number;
+  onChange: (files: UploadFile[]) => void;
+}
+
+export const ParkingPermitFileUpload = ({
+  category,
+  categoryLabel,
+  dataCy,
+  errorMessage,
+  files,
+  maxFileSizeMB,
+  onChange,
+}: ParkingPermitFileUploadProps) => (
+  <>
+    {files.length > 0 ? (
+      <FileUpload.List name="files">
+        {files.map((file, index) => (
+          <FileUpload.ListItem
+            key={file.id}
+            index={index}
+            file={file}
+            categoryProps={{ categories: { [category]: categoryLabel } }}
+            actionsProps={{
+              showRemove: true,
+              onRemove: () => onChange(files.filter((candidate) => candidate !== file)),
+            }}
+          />
+        ))}
+      </FileUpload.List>
+    ) : (
+      <FileUpload.Field
+        className="inline-block w-full"
+        accept={ACCEPTED_UPLOAD_FILETYPES}
+        variant="horizontal"
+        name="files"
+        maxFileSizeMB={maxFileSizeMB}
+        data-cy={dataCy}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    )}
+    {errorMessage && (
+      <FormErrorMessage className="text-error" role="alert">
+        {errorMessage}
+      </FormErrorMessage>
+    )}
+  </>
+);

--- a/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-lost-form.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-lost-form.component.tsx
@@ -12,7 +12,7 @@ import {
   useSnackbar,
 } from '@sk-web-gui/react';
 import { toBase64 } from '@utils/toBase64';
-import { validateFileCount } from '@utils/upload-limits';
+import { MAX_FILES_PER_UPLOAD, validateFileCount } from '@utils/upload-limits';
 import { ArrowRight } from 'lucide-react';
 import { useController, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -50,7 +50,10 @@ export const ParkingPermitLostForm = ({
   const { field: filesField, fieldState: filesFieldState } = useController({
     control: form.control,
     name: 'files',
-    rules: { validate: validateFileCount },
+    rules: {
+      validate: (files) =>
+        validateFileCount(files, t('common:uploadErrors.UPLOAD_TOO_MANY_FILES', { max: MAX_FILES_PER_UPLOAD })),
+    },
   });
 
   const onSubmit = async (data: LostPermitFormModel) => {
@@ -97,6 +100,7 @@ export const ParkingPermitLostForm = ({
           fallbackMessage: t('decisions:parkingPermit.lost.form.errorMessage'),
           inlineFields: ['files', 'policeReportNumber'],
           onFormError: (message) => toastMessage({ position: 'bottom', closeable: false, message, status: 'error' }),
+          translate: t,
         });
       }
     }

--- a/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-lost-form.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-lost-form.component.tsx
@@ -1,8 +1,7 @@
+import { applyApiErrorToForm } from '@services/form-api-error';
 import { useApi } from '@services/api-service';
-import { ACCEPTED_UPLOAD_FILETYPES } from '@utils/accepted-file-types';
 import {
   Button,
-  FileUpload,
   FormControl,
   FormErrorMessage,
   FormHelperText,
@@ -15,8 +14,9 @@ import {
 import { toBase64 } from '@utils/toBase64';
 import { validateFileCount } from '@utils/upload-limits';
 import { ArrowRight } from 'lucide-react';
-import { useForm } from 'react-hook-form';
+import { useController, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { ParkingPermitFileUpload } from './parkingpermit-file-upload.component';
 
 const MAX_FILE_SIZE_MB = 25;
 
@@ -46,6 +46,11 @@ export const ParkingPermitLostForm = ({
     url: '/assets/parkingpermit/lost',
     method: 'post',
     axiosParameters: { headers: { 'Content-Type': 'multipart/form-data' } },
+  });
+  const { field: filesField, fieldState: filesFieldState } = useController({
+    control: form.control,
+    name: 'files',
+    rules: { validate: validateFileCount },
   });
 
   const onSubmit = async (data: LostPermitFormModel) => {
@@ -87,20 +92,17 @@ export const ParkingPermitLostForm = ({
           status: 'success',
         });
         setFormState('success');
-      } catch {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: t('decisions:parkingPermit.lost.form.errorMessage'),
-          status: 'error',
+      } catch (error) {
+        applyApiErrorToForm<LostPermitFormModel>(error, form, {
+          fallbackMessage: t('decisions:parkingPermit.lost.form.errorMessage'),
+          inlineFields: ['files', 'policeReportNumber'],
+          onFormError: (message) => toastMessage({ position: 'bottom', closeable: false, message, status: 'error' }),
         });
       }
     }
   };
 
-  const files = form.watch('files');
-  // files is set programmatically (no registered input), so attach the rule here.
-  form.register('files', { validate: validateFileCount });
+  const files = filesField.value;
 
   return (
     <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-y-56">
@@ -126,44 +128,15 @@ export const ParkingPermitLostForm = ({
       <FormControl className="w-full">
         <FormLabel>{t('decisions:parkingPermit.lost.form.attachPoliceReport')}</FormLabel>
         <FormHelperText className="mb-12">{t('decisions:parkingPermit.lost.form.allowedFileTypes')}</FormHelperText>
-        {files && files.length > 0 ? (
-          <FileUpload.List name="files">
-            {files.map((file, i) => (
-              <FileUpload.ListItem
-                key={file.id}
-                index={i}
-                file={file}
-                categoryProps={{
-                  categories: { POLICE_REPORT: t('decisions:parkingPermit.lost.form.policeReportCategory') },
-                }}
-                actionsProps={{
-                  showRemove: true,
-                  onRemove: () =>
-                    form.setValue(
-                      'files',
-                      form.watch('files').filter((f) => f !== file),
-                      { shouldValidate: true }
-                    ),
-                }}
-              />
-            ))}
-          </FileUpload.List>
-        ) : (
-          <FileUpload.Field
-            className="inline-block w-full"
-            accept={ACCEPTED_UPLOAD_FILETYPES}
-            variant="horizontal"
-            name="files"
-            maxFileSizeMB={MAX_FILE_SIZE_MB}
-            data-cy="police-report-file-upload"
-            onChange={(e) => {
-              form.setValue('files', e.target.value, { shouldValidate: true });
-            }}
-          />
-        )}
-        {form.formState.errors.files && (
-          <FormErrorMessage className="text-error">{form.formState.errors.files.message}</FormErrorMessage>
-        )}
+        <ParkingPermitFileUpload
+          category="POLICE_REPORT"
+          categoryLabel={t('decisions:parkingPermit.lost.form.policeReportCategory')}
+          dataCy="police-report-file-upload"
+          errorMessage={filesFieldState.error?.message}
+          files={files}
+          maxFileSizeMB={MAX_FILE_SIZE_MB}
+          onChange={filesField.onChange}
+        />
       </FormControl>
 
       <div className="flex flex-col desktop:flex-row gap-x-24 gap-y-20 desktop:items-center mt-40">

--- a/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-lost-form.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-lost-form.component.tsx
@@ -13,6 +13,7 @@ import {
   useSnackbar,
 } from '@sk-web-gui/react';
 import { toBase64 } from '@utils/toBase64';
+import { validateFileCount } from '@utils/upload-limits';
 import { ArrowRight } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -98,6 +99,8 @@ export const ParkingPermitLostForm = ({
   };
 
   const files = form.watch('files');
+  // files is set programmatically (no registered input), so attach the rule here.
+  form.register('files', { validate: validateFileCount });
 
   return (
     <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-y-56">
@@ -138,7 +141,8 @@ export const ParkingPermitLostForm = ({
                   onRemove: () =>
                     form.setValue(
                       'files',
-                      form.watch('files').filter((f) => f !== file)
+                      form.watch('files').filter((f) => f !== file),
+                      { shouldValidate: true }
                     ),
                 }}
               />
@@ -153,7 +157,7 @@ export const ParkingPermitLostForm = ({
             maxFileSizeMB={MAX_FILE_SIZE_MB}
             data-cy="police-report-file-upload"
             onChange={(e) => {
-              form.setValue('files', e.target.value);
+              form.setValue('files', e.target.value, { shouldValidate: true });
             }}
           />
         )}

--- a/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-renewal-form.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-renewal-form.component.tsx
@@ -17,6 +17,7 @@ import {
   useSnackbar,
 } from '@sk-web-gui/react';
 import { toBase64 } from '@utils/toBase64';
+import { validateFileCount } from '@utils/upload-limits';
 import { ArrowRight } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -164,6 +165,8 @@ export const ParkingPermitRenewalForm = ({
   };
 
   const files = form.watch('files');
+  // files is set programmatically (no registered input), so attach the rule here.
+  form.register('files', { validate: validateFileCount });
 
   return (
     <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-y-56">
@@ -534,7 +537,8 @@ export const ParkingPermitRenewalForm = ({
                   onRemove: () =>
                     form.setValue(
                       'files',
-                      form.watch('files').filter((f) => f !== file)
+                      form.watch('files').filter((f) => f !== file),
+                      { shouldValidate: true }
                     ),
                 }}
               />
@@ -548,9 +552,12 @@ export const ParkingPermitRenewalForm = ({
             name="files"
             maxFileSizeMB={MAX_FILE_SIZE_MB}
             onChange={(e) => {
-              form.setValue('files', e.target.value);
+              form.setValue('files', e.target.value, { shouldValidate: true });
             }}
           />
+        )}
+        {form.formState.errors.files && (
+          <FormErrorMessage className="text-error">{form.formState.errors.files.message}</FormErrorMessage>
         )}
       </FormControl>
       <div className="flex flex-col desktop:flex-row gap-x-24 gap-y-20 desktop:items-center mt-40">

--- a/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-renewal-form.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-renewal-form.component.tsx
@@ -1,9 +1,8 @@
+import { applyApiErrorToForm } from '@services/form-api-error';
 import { useApi } from '@services/api-service';
-import { ACCEPTED_UPLOAD_FILETYPES } from '@utils/accepted-file-types';
 import {
   Button,
   Checkbox,
-  FileUpload,
   FormControl,
   FormErrorMessage,
   FormHelperText,
@@ -19,8 +18,9 @@ import {
 import { toBase64 } from '@utils/toBase64';
 import { validateFileCount } from '@utils/upload-limits';
 import { ArrowRight } from 'lucide-react';
-import { useForm } from 'react-hook-form';
+import { useController, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { ParkingPermitFileUpload } from './parkingpermit-file-upload.component';
 
 const MAX_FILE_SIZE_MB = 50;
 
@@ -97,6 +97,11 @@ export const ParkingPermitRenewalForm = ({
     method: 'post',
     axiosParameters: { headers: { 'Content-Type': 'multipart/form-data' } },
   });
+  const { field: filesField, fieldState: filesFieldState } = useController({
+    control: form.control,
+    name: 'files',
+    rules: { validate: validateFileCount },
+  });
 
   const onSubmit = async (data: PermitRenewalFormModel) => {
     const confirmed = await confirm.showConfirmation(
@@ -153,20 +158,17 @@ export const ParkingPermitRenewalForm = ({
           status: 'success',
         });
         setFormState('success');
-      } catch {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: t('decisions:parkingPermit.renewal.form.errorMessage'),
-          status: 'error',
+      } catch (error) {
+        applyApiErrorToForm<PermitRenewalFormModel>(error, form, {
+          fallbackMessage: t('decisions:parkingPermit.renewal.form.errorMessage'),
+          inlineFields: ['expirationDate', 'files'],
+          onFormError: (message) => toastMessage({ position: 'bottom', closeable: false, message, status: 'error' }),
         });
       }
     }
   };
 
-  const files = form.watch('files');
-  // files is set programmatically (no registered input), so attach the rule here.
-  form.register('files', { validate: validateFileCount });
+  const files = filesField.value;
 
   return (
     <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-y-56">
@@ -520,45 +522,14 @@ export const ParkingPermitRenewalForm = ({
       <FormControl className="w-full">
         <FormLabel>{t('decisions:parkingPermit.renewal.form.attachMedicalCertificate')}</FormLabel>
         <FormHelperText className="mb-12">{t('decisions:parkingPermit.renewal.form.allowedFileTypes')}</FormHelperText>
-        {files && files.length > 0 ? (
-          <FileUpload.List name="files">
-            {files.map((file, i) => (
-              <FileUpload.ListItem
-                key={file.id}
-                index={i}
-                file={file}
-                categoryProps={{
-                  categories: {
-                    MEDICAL_CONFIRMATION: t('decisions:parkingPermit.renewal.form.medicalCertificateCategory'),
-                  },
-                }}
-                actionsProps={{
-                  showRemove: true,
-                  onRemove: () =>
-                    form.setValue(
-                      'files',
-                      form.watch('files').filter((f) => f !== file),
-                      { shouldValidate: true }
-                    ),
-                }}
-              />
-            ))}
-          </FileUpload.List>
-        ) : (
-          <FileUpload.Field
-            className="inline-block w-full"
-            accept={ACCEPTED_UPLOAD_FILETYPES}
-            variant="horizontal"
-            name="files"
-            maxFileSizeMB={MAX_FILE_SIZE_MB}
-            onChange={(e) => {
-              form.setValue('files', e.target.value, { shouldValidate: true });
-            }}
-          />
-        )}
-        {form.formState.errors.files && (
-          <FormErrorMessage className="text-error">{form.formState.errors.files.message}</FormErrorMessage>
-        )}
+        <ParkingPermitFileUpload
+          category="MEDICAL_CONFIRMATION"
+          categoryLabel={t('decisions:parkingPermit.renewal.form.medicalCertificateCategory')}
+          errorMessage={filesFieldState.error?.message}
+          files={files}
+          maxFileSizeMB={MAX_FILE_SIZE_MB}
+          onChange={filesField.onChange}
+        />
       </FormControl>
       <div className="flex flex-col desktop:flex-row gap-x-24 gap-y-20 desktop:items-center mt-40">
         <Button size="lg" variant="secondary" onClick={() => setFormState('showInfo')}>

--- a/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-renewal-form.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/decicions-and-documents/parkingpermits/parkingpermit-renewal-form.component.tsx
@@ -16,7 +16,7 @@ import {
   useSnackbar,
 } from '@sk-web-gui/react';
 import { toBase64 } from '@utils/toBase64';
-import { validateFileCount } from '@utils/upload-limits';
+import { MAX_FILES_PER_UPLOAD, validateFileCount } from '@utils/upload-limits';
 import { ArrowRight } from 'lucide-react';
 import { useController, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -100,7 +100,10 @@ export const ParkingPermitRenewalForm = ({
   const { field: filesField, fieldState: filesFieldState } = useController({
     control: form.control,
     name: 'files',
-    rules: { validate: validateFileCount },
+    rules: {
+      validate: (files) =>
+        validateFileCount(files, t('common:uploadErrors.UPLOAD_TOO_MANY_FILES', { max: MAX_FILES_PER_UPLOAD })),
+    },
   });
 
   const onSubmit = async (data: PermitRenewalFormModel) => {
@@ -163,6 +166,7 @@ export const ParkingPermitRenewalForm = ({
           fallbackMessage: t('decisions:parkingPermit.renewal.form.errorMessage'),
           inlineFields: ['expirationDate', 'files'],
           onFormError: (message) => toastMessage({ position: 'bottom', closeable: false, message, status: 'error' }),
+          translate: t,
         });
       }
     }

--- a/frontend/src/layouts/pages/mypages-sections/profile/components/contact-settings-form-logic.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/profile/components/contact-settings-form-logic.component.tsx
@@ -120,7 +120,7 @@ export default function ContactSettingsFormLogic({
     if (onSubmit) {
       onSubmit(values, context);
     } else {
-      const apiCall = isPatch() ? await patchMutation.mutateAsync : await postMutation.mutateAsync;
+      const apiCall = isPatch() ? patchMutation.mutateAsync : postMutation.mutateAsync;
       const data: Partial<ClientContactSetting> = _.merge(formData, {
         id: formData?.id,
         email: values.email,
@@ -135,14 +135,14 @@ export default function ContactSettingsFormLogic({
           snailmail: values.decicionsAndDocuments?.snailmail,
         },
       });
-      const res = await apiCall(data);
-      if (!res.error) {
+      try {
+        const res = await apiCall(data);
         reset(res);
         queryClient.invalidateQueries({
           queryKey: ['/contactsettings'],
         });
         if (onSubmitSuccess) onSubmitSuccess();
-      } else {
+      } catch {
         if (onSubmitFailed) onSubmitFailed();
       }
     }

--- a/frontend/src/layouts/pages/valj-foretag/no-represent.tsx
+++ b/frontend/src/layouts/pages/valj-foretag/no-represent.tsx
@@ -15,7 +15,7 @@ export const NoRepresent: React.FC = ({}) => {
 
   const goPrivate = async () => {
     const res = await setRepresenting({ mode: RepresentingMode.PRIVATE, organizationNumber: undefined });
-    if (res?.error) return;
+    if (!res.success) return;
     router.push('/privat/oversikt');
   };
 

--- a/frontend/src/layouts/pages/valj-foretag/valj-foretag.component.tsx
+++ b/frontend/src/layouts/pages/valj-foretag/valj-foretag.component.tsx
@@ -41,7 +41,7 @@ export default function ValjForetag() {
 
   const onContinue = async () => {
     const res = await setRepresenting({ organizationNumber: choosen, mode: RepresentingMode.BUSINESS });
-    if (!res.error) {
+    if (res.success) {
       const path = searchParams?.get('path') || '';
       const myPagesAdjustedPathname = getAdjustedPathname(path, representingMode);
       router.push(

--- a/frontend/src/layouts/site-menu/site-menu-items.tsx
+++ b/frontend/src/layouts/site-menu/site-menu-items.tsx
@@ -12,6 +12,8 @@ import { useApi, useApiService } from '../../services/api-service';
 import { getRepresentingModeRoute, newRepresentingModePathname } from '../../utils/representingModeRoute';
 import { toRepresentingLabel } from '@utils/to-representing-label';
 
+type SetRepresentingResult = { data: RepresentingEntity; success: true } | { error: unknown; success: false };
+
 export const useRepresentingSwitch = () => {
   const queryClient = useApiService((s) => s.queryClient);
   const representingMutation = useApi<RepresentingEntity>({
@@ -24,21 +26,18 @@ export const useRepresentingSwitch = () => {
     queryClient.invalidateQueries();
   };
 
-  const setRepresenting = async (representingDto: RepresentingEntityDto) => {
+  const setRepresenting = async (representingDto: RepresentingEntityDto): Promise<SetRepresentingResult> => {
     queryClient.cancelQueries();
     try {
       const res = await representingMutation.mutateAsync(representingDto);
-      if (!res.error) {
-        invalidateQueries();
-      } else {
-        if (representingDto.mode === RepresentingMode.BUSINESS) {
-          router.push(`${getRepresentingModeRoute(RepresentingMode.BUSINESS)}/valj-foretag`);
-        }
-      }
-      return res;
+      invalidateQueries();
+      return { data: res, success: true };
     } catch (err) {
       console.error('Could not set representing mode in backend');
-      return { error: err };
+      if (representingDto.mode === RepresentingMode.BUSINESS) {
+        router.push(`${getRepresentingModeRoute(RepresentingMode.BUSINESS)}/valj-foretag`);
+      }
+      return { error: err, success: false };
     }
   };
 
@@ -78,8 +77,9 @@ export const MyPagesBusinessSwitch: React.FC<{ submitCallback?: () => void }> = 
   const { isMinDesktop } = useThemeQueries();
 
   const setEngagement = async (value?: string) => {
-    const res = (await setRepresenting({ organizationNumber: value })) as RepresentingEntity;
-    setRepresentingName(toRepresentingLabel(res));
+    const res = await setRepresenting({ organizationNumber: value });
+    if (!res.success) return;
+    setRepresentingName(toRepresentingLabel(res.data));
 
     if (submitCallback) submitCallback();
   };
@@ -143,4 +143,3 @@ export const MyPagesBusinessSwitch: React.FC<{ submitCallback?: () => void }> = 
     </label>
   );
 };
-

--- a/frontend/src/services/api-service.test.tsx
+++ b/frontend/src/services/api-service.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { apiService, getApiErrorResponse, useApi } from './api-service';
+import { applyApiErrorToForm } from './form-api-error';
+
+jest.mock('@sk-web-gui/react', () => ({ __DEV__: false }));
+
+const createApiError = (data: unknown) =>
+  Object.assign(new Error('Request failed'), {
+    isAxiosError: true,
+    response: { data, status: 400 },
+  });
+
+describe('API error handling', () => {
+  it('parses the typed error response returned by the backend', () => {
+    const error = createApiError({
+      code: 'UPLOAD_TOO_MANY_FILES',
+      field: 'files',
+      message: 'Du kan bifoga högst 10 filer.',
+    });
+
+    expect(getApiErrorResponse(error)).toEqual({
+      code: 'UPLOAD_TOO_MANY_FILES',
+      field: 'files',
+      message: 'Du kan bifoga högst 10 filer.',
+    });
+  });
+
+  it('places a field-specific API error on the matching form field', () => {
+    const setError = jest.fn();
+    const onFormError = jest.fn();
+    const error = createApiError({ field: 'files', message: 'Du kan bifoga högst 10 filer.' });
+
+    applyApiErrorToForm<{ files: never[] }>(
+      error,
+      { getValues: () => ({ files: [] }), setError },
+      { fallbackMessage: 'Ett oväntat fel inträffade.', inlineFields: ['files'], onFormError }
+    );
+
+    expect(setError).toHaveBeenCalledWith('files', {
+      message: 'Du kan bifoga högst 10 filer.',
+      type: 'server',
+    });
+    expect(onFormError).not.toHaveBeenCalled();
+  });
+
+  it('places errors at form level when the field has no inline error surface', () => {
+    const setError = jest.fn();
+    const onFormError = jest.fn();
+    const error = createApiError({
+      field: 'reason',
+      message: 'Ett textfält får innehålla högst 1 MB.',
+    });
+
+    applyApiErrorToForm<{ files: never[]; reason: string }>(
+      error,
+      { getValues: () => ({ files: [], reason: '' }), setError },
+      { fallbackMessage: 'Ett oväntat fel inträffade.', inlineFields: ['files'], onFormError }
+    );
+
+    expect(setError).not.toHaveBeenCalled();
+    expect(onFormError).toHaveBeenCalledWith('Ett textfält får innehålla högst 1 MB.');
+  });
+
+  it("keeps failed mutations in TanStack Query's error path", async () => {
+    const error = createApiError({ message: 'Uppladdningen kunde inte behandlas.' });
+    jest.spyOn(apiService, 'post').mockRejectedValueOnce(error);
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useApi({ method: 'post', url: '/upload' }, queryClient));
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({})).rejects.toBe(error);
+    });
+  });
+});

--- a/frontend/src/services/api-service.test.tsx
+++ b/frontend/src/services/api-service.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
+import { TFunction } from 'i18next';
 import { apiService, getApiErrorResponse, useApi } from './api-service';
 import { applyApiErrorToForm } from './form-api-error';
 
@@ -17,30 +18,35 @@ describe('API error handling', () => {
     const error = createApiError({
       code: 'UPLOAD_TOO_MANY_FILES',
       field: 'files',
-      message: 'Du kan bifoga högst 10 filer.',
+      params: { max: 10 },
     });
 
     expect(getApiErrorResponse(error)).toEqual({
       code: 'UPLOAD_TOO_MANY_FILES',
       field: 'files',
-      message: 'Du kan bifoga högst 10 filer.',
+      params: { max: 10 },
     });
   });
 
-  it('places a field-specific API error on the matching form field', () => {
+  it('translates a coded API error and places it on the matching form field', () => {
     const setError = jest.fn();
     const onFormError = jest.fn();
-    const error = createApiError({ field: 'files', message: 'Du kan bifoga högst 10 filer.' });
+    const translate = jest.fn(() => 'localized upload error') as unknown as TFunction;
+    const error = createApiError({ code: 'UPLOAD_TOO_MANY_FILES', field: 'files', params: { max: 10 } });
 
     applyApiErrorToForm<{ files: never[] }>(
       error,
       { getValues: () => ({ files: [] }), setError },
-      { fallbackMessage: 'Ett oväntat fel inträffade.', inlineFields: ['files'], onFormError }
+      { fallbackMessage: 'fallback error', inlineFields: ['files'], onFormError, translate }
     );
 
     expect(setError).toHaveBeenCalledWith('files', {
-      message: 'Du kan bifoga högst 10 filer.',
+      message: 'localized upload error',
       type: 'server',
+    });
+    expect(translate).toHaveBeenCalledWith('common:uploadErrors.UPLOAD_TOO_MANY_FILES', {
+      defaultValue: 'fallback error',
+      max: 10,
     });
     expect(onFormError).not.toHaveBeenCalled();
   });
@@ -48,19 +54,21 @@ describe('API error handling', () => {
   it('places errors at form level when the field has no inline error surface', () => {
     const setError = jest.fn();
     const onFormError = jest.fn();
+    const translate = jest.fn(() => 'localized field error') as unknown as TFunction;
     const error = createApiError({
+      code: 'UPLOAD_FIELD_TOO_LARGE',
       field: 'reason',
-      message: 'Ett textfält får innehålla högst 1 MB.',
+      params: { max: 1 },
     });
 
     applyApiErrorToForm<{ files: never[]; reason: string }>(
       error,
       { getValues: () => ({ files: [], reason: '' }), setError },
-      { fallbackMessage: 'Ett oväntat fel inträffade.', inlineFields: ['files'], onFormError }
+      { fallbackMessage: 'fallback error', inlineFields: ['files'], onFormError, translate }
     );
 
     expect(setError).not.toHaveBeenCalled();
-    expect(onFormError).toHaveBeenCalledWith('Ett textfält får innehålla högst 1 MB.');
+    expect(onFormError).toHaveBeenCalledWith('localized field error');
   });
 
   it("keeps failed mutations in TanStack Query's error path", async () => {

--- a/frontend/src/services/api-service.ts
+++ b/frontend/src/services/api-service.ts
@@ -1,6 +1,5 @@
 import { __DEV__ } from '@sk-web-gui/react';
 import {
-  DefaultError,
   QueryClient,
   QueryKey,
   UseMutationOptions,
@@ -20,11 +19,31 @@ export interface ApiResponse<T> {
   message: string;
 }
 
+interface ApiErrorResponse {
+  code?: string;
+  field?: string;
+  message: string;
+}
+
+const isApiErrorResponse = (value: unknown): value is ApiErrorResponse =>
+  typeof value === 'object' && value !== null && 'message' in value && typeof value.message === 'string';
+
+export const getApiErrorResponse = (error: unknown): ApiErrorResponse | undefined => {
+  if (!axios.isAxiosError(error) || !isApiErrorResponse(error.response?.data)) return undefined;
+
+  const { code, field, message } = error.response.data;
+  return {
+    message,
+    ...(typeof code === 'string' ? { code } : {}),
+    ...(typeof field === 'string' ? { field } : {}),
+  };
+};
+
 const handleError = (error: AxiosError | unknown) => {
   const axiosErr = axios.isAxiosError(error) ? error : null;
   if (axiosErr?.response?.status === 401 && !window?.location.pathname.includes('login')) {
     const path = window.location.pathname.includes('/valj-foretag') ? '/' : window.location.pathname;
-    const message = (axiosErr.response?.data as { message?: string })?.message ?? '';
+    const message = getApiErrorResponse(error)?.message ?? '';
     window.location.href = `/login?path=${path}&failMessage=${message}`;
   }
 };
@@ -206,7 +225,7 @@ export function useApi<
 >(
   props: UseApiMutationProps<TQueryFnData, TError, TData, TQueryKey, TContext>,
   queryClient?: QueryClient
-): UseMutationResult<TData & { error?: DefaultError }, TError, unknown, TContext>;
+): UseMutationResult<TData, TError, unknown, TContext>;
 
 export function useApi<
   TQueryFnData = unknown,
@@ -244,8 +263,8 @@ export function useApi<
         dataHandler(res.data.data)
       );
     } catch (error) {
-      handleError(error as AxiosError);
-      return { error };
+      handleError(error);
+      throw error;
     }
   };
 
@@ -276,12 +295,7 @@ export function useApi<
           return { newBody };
         },
         onSuccess: (result) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          _queryClient.setQueryData<TQueryFnData & { error?: DefaultError }>(queryKey, result as any);
-        },
-        throwOnError: (error) => {
-          handleError(error as AxiosError);
-          return false;
+          _queryClient.setQueryData<TData>(queryKey, result as TData);
         },
         ...mutationOptions,
       },

--- a/frontend/src/services/api-service.ts
+++ b/frontend/src/services/api-service.ts
@@ -22,20 +22,31 @@ export interface ApiResponse<T> {
 interface ApiErrorResponse {
   code?: string;
   field?: string;
-  message: string;
+  message?: string;
+  params?: ApiErrorParams;
+}
+
+interface ApiErrorParams {
+  max: number;
 }
 
 const isApiErrorResponse = (value: unknown): value is ApiErrorResponse =>
-  typeof value === 'object' && value !== null && 'message' in value && typeof value.message === 'string';
+  typeof value === 'object' &&
+  value !== null &&
+  (('message' in value && typeof value.message === 'string') || ('code' in value && typeof value.code === 'string'));
+
+const isApiErrorParams = (value: unknown): value is ApiErrorParams =>
+  typeof value === 'object' && value !== null && 'max' in value && typeof value.max === 'number';
 
 export const getApiErrorResponse = (error: unknown): ApiErrorResponse | undefined => {
   if (!axios.isAxiosError(error) || !isApiErrorResponse(error.response?.data)) return undefined;
 
-  const { code, field, message } = error.response.data;
+  const { code, field, message, params } = error.response.data;
   return {
-    message,
     ...(typeof code === 'string' ? { code } : {}),
     ...(typeof field === 'string' ? { field } : {}),
+    ...(typeof message === 'string' ? { message } : {}),
+    ...(isApiErrorParams(params) ? { params } : {}),
   };
 };
 

--- a/frontend/src/services/form-api-error.ts
+++ b/frontend/src/services/form-api-error.ts
@@ -1,3 +1,4 @@
+import { TFunction } from 'i18next';
 import { FieldPath, FieldValues } from 'react-hook-form';
 import { getApiErrorResponse } from './api-service';
 
@@ -10,22 +11,24 @@ interface ApiFormErrorOptions<TFieldValues extends FieldValues> {
   fallbackMessage: string;
   inlineFields: readonly FieldPath<TFieldValues>[];
   onFormError: (message: string) => void;
+  translate: TFunction;
 }
 
 export const applyApiErrorToForm = <TFieldValues extends FieldValues>(
   error: unknown,
   form: FormErrorTarget<TFieldValues>,
-  { fallbackMessage, inlineFields, onFormError }: ApiFormErrorOptions<TFieldValues>
+  { fallbackMessage, inlineFields, onFormError, translate }: ApiFormErrorOptions<TFieldValues>
 ): void => {
   const response = getApiErrorResponse(error);
-  const message = response?.message ?? fallbackMessage;
+  const message = response?.code?.startsWith('UPLOAD_')
+    ? translate(`common:uploadErrors.${response.code}`, {
+        ...response.params,
+        defaultValue: response.message ?? fallbackMessage,
+      })
+    : (response?.message ?? fallbackMessage);
   const field = response?.field;
 
-  if (
-    field &&
-    Object.prototype.hasOwnProperty.call(form.getValues(), field) &&
-    inlineFields.includes(field as FieldPath<TFieldValues>)
-  ) {
+  if (field && Object.hasOwn(form.getValues(), field) && inlineFields.includes(field as FieldPath<TFieldValues>)) {
     form.setError(field as FieldPath<TFieldValues>, { message, type: 'server' });
     return;
   }

--- a/frontend/src/services/form-api-error.ts
+++ b/frontend/src/services/form-api-error.ts
@@ -1,0 +1,34 @@
+import { FieldPath, FieldValues } from 'react-hook-form';
+import { getApiErrorResponse } from './api-service';
+
+interface FormErrorTarget<TFieldValues extends FieldValues> {
+  getValues: () => TFieldValues;
+  setError: (field: FieldPath<TFieldValues>, error: { message: string; type: string }) => void;
+}
+
+interface ApiFormErrorOptions<TFieldValues extends FieldValues> {
+  fallbackMessage: string;
+  inlineFields: readonly FieldPath<TFieldValues>[];
+  onFormError: (message: string) => void;
+}
+
+export const applyApiErrorToForm = <TFieldValues extends FieldValues>(
+  error: unknown,
+  form: FormErrorTarget<TFieldValues>,
+  { fallbackMessage, inlineFields, onFormError }: ApiFormErrorOptions<TFieldValues>
+): void => {
+  const response = getApiErrorResponse(error);
+  const message = response?.message ?? fallbackMessage;
+  const field = response?.field;
+
+  if (
+    field &&
+    Object.prototype.hasOwnProperty.call(form.getValues(), field) &&
+    inlineFields.includes(field as FieldPath<TFieldValues>)
+  ) {
+    form.setError(field as FieldPath<TFieldValues>, { message, type: 'server' });
+    return;
+  }
+
+  onFormError(message);
+};

--- a/frontend/src/utils/upload-limits.ts
+++ b/frontend/src/utils/upload-limits.ts
@@ -2,7 +2,7 @@ import { UploadFile } from '@sk-web-gui/react';
 
 // UX mirror of the backend upload policy (backend/src/utils/files/fileUploadSettings.ts).
 // The backend is the enforcing authority and rejects requests over the limit with 400.
-const MAX_FILES_PER_UPLOAD = 10;
+export const MAX_FILES_PER_UPLOAD = 10;
 
-export const validateFileCount = (files?: UploadFile[]) =>
-  !files || files.length <= MAX_FILES_PER_UPLOAD || `Du kan bifoga högst ${MAX_FILES_PER_UPLOAD} filer.`;
+export const validateFileCount = (files: UploadFile[] | undefined, errorMessage: string) =>
+  !files || files.length <= MAX_FILES_PER_UPLOAD || errorMessage;

--- a/frontend/src/utils/upload-limits.ts
+++ b/frontend/src/utils/upload-limits.ts
@@ -1,0 +1,8 @@
+import { UploadFile } from '@sk-web-gui/react';
+
+// UX mirror of the backend upload policy (backend/src/utils/files/fileUploadSettings.ts).
+// The backend is the enforcing authority and rejects requests over the limit with 400.
+const MAX_FILES_PER_UPLOAD = 10;
+
+export const validateFileCount = (files?: UploadFile[]) =>
+  !files || files.length <= MAX_FILES_PER_UPLOAD || `Du kan bifoga högst ${MAX_FILES_PER_UPLOAD} filer.`;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -969,7 +969,7 @@
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
-"@jest/globals@^29.7.0":
+"@jest/globals@29.7.0", "@jest/globals@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.7.0.tgz#8d9290f9ec47ff772607fa864ca1d5a2efae1d4d"
   integrity sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==


### PR DESCRIPTION
## Varför

Filuppladdningen använder Multers memory storage. Tidigare var bara storleken per fil begränsad; antal filer, fält och totala multipart-delar var obegränsade. En autentiserad angripare eller trasig klient kunde därför driva parserarbete och minnesanvändning utan en fast övre gräns.

## Ändring och nytta

- Behåller befintligt verksamhetskrav på högst 50 MB per fil.
- Begränsar en request till 10 filer, 50 textfält, 60 multipart-delar och 1 MB per textfält.
- Samlar gränserna i den befintliga `fileUploadSettings`, som nu är kanonisk ägare för uploadpolicyn.
- Lägger till ett kontraktstest för samtliga parsergränser.
- Mappar Multers limit-fel till 400 med begripligt meddelande i felmiddlewaren (tidigare blev de generiska 500), med regressionstest.
- Speglar maxantalet filer i de tre uppladdningsformulären med ett tydligt valideringsfel innan submit; backendpolicyn är fortsatt den enda auktoriteten.
- Deklarerar `multer` som direkt beroende (importerades redan direkt men löstes bara transitivt via routing-controllers).

Fördelen är en förutsägbar övre gräns för enskilda multipart-requests och ett extra skydd även efter Multer-patchen.

## Verifiering

- Nya riktade tester: parsergränser 1/1 samt felmappning 3/3.
- Hela backendsviten: 103/103 tester.
- `yarn type-check`, `yarn lint`, `yarn knip`.

## Risk och återställning

Avsedd beteendeförändring: requests med fler än 10 filer eller 50 fält avvisas med 400. UI:t hade tidigare ingen övre gräns för antal bifogade filer; nu valideras gränsen även i formulären så att användaren får ett begripligt fel i stället för ett serverfel. Om ett dokumenterat verksamhetsflöde behöver mer ska den centrala policyn höjas tillsammans med ett test, inte tas bort. Rollback är revert av policycommitten.

