### PR TITLE
fix(auth): harden SAML validation and redirects

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -52,8 +52,14 @@ import { Profile } from './interfaces/profile.interface';
 import { RepresentingMode } from './interfaces/representing.interface';
 import { User } from './interfaces/users.interface';
 import { additionalConverters } from './utils/custom-validation-classes';
-import { isValidUrl } from './utils/util';
 import { getBusinessEngagements, mapEngagements } from './services/legal-entity.service';
+import {
+  getAllowedRedirectUrl,
+  getRelayStateRedirects,
+  getSamlSecurityOptions,
+  getSessionCookieOptions,
+  serializeRelayStateRedirects,
+} from './auth/saml-security';
 
 const SessionStoreCreate = SESSION_MEMORY ? createMemoryStore(session) : createFileStore(session);
 const sessionTTL = 4 * 24 * 60 * 60;
@@ -79,12 +85,9 @@ const samlStrategy = new Strategy(
     issuer: SAML_ISSUER ?? '',
     signatureAlgorithm: 'sha256',
     digestAlgorithm: 'sha256',
-    wantAssertionsSigned: false,
-    wantAuthnResponseSigned: false,
-    audience: false,
+    ...getSamlSecurityOptions(SAML_ISSUER ?? ''),
     logoutUrl: SAML_LOGOUT_URL ?? '',
     logoutCallbackUrl: SAML_LOGOUT_CALLBACK_URL,
-    acceptedClockSkewMs: -1,
   },
   async function (samlProfile: SamlProfile | null, done: VerifiedCallback) {
     if (!samlProfile) {
@@ -215,11 +218,7 @@ class App {
         resave: false,
         saveUninitialized: false,
         store: sessionStore,
-        cookie: {
-          httpOnly: this.env === 'production' && process.env.ENVIRONMENT !== 'TEST',
-          sameSite: process.env.ENVIRONMENT === 'TEST' ? 'lax' : 'none',
-          secure: this.env === 'production' && process.env.ENVIRONMENT !== 'TEST',
-        },
+        cookie: getSessionCookieOptions(this.env === 'production', process.env.ENVIRONMENT === 'TEST'),
       }),
     );
 
@@ -231,20 +230,20 @@ class App {
       `${BASE_URL_PREFIX}/saml/login`,
       samlLimiter,
       (req, _res, next) => {
-        if (req.session.returnTo) {
-          req.query.RelayState = req.session.returnTo;
-        } else if (req.query.successRedirect) {
-          req.query.RelayState = req.query.successRedirect;
-        }
+        const relayState = req.session.returnTo ?? req.query.successRedirect;
+        const { successRedirect, failureRedirect } = getRelayStateRedirects(relayState, ORIGIN);
+
         // Carry the representing mode through the SAML round-trip via RelayState (the IdP
         // echoes it back in the callback). The pre-auth session cannot be relied on: its
         // cookie is not sent on the cross-site IdP callback POST (sameSite=lax), and
         // passport's req.login regenerates the session. representing is therefore set in
         // the callback, after req.login, on the authenticated session.
-        if (req.query.representingMode && typeof req.query.RelayState === 'string' && isValidUrl(req.query.RelayState)) {
-          const relay = new URL(req.query.RelayState);
-          relay.searchParams.set('representingMode', req.query.representingMode as string);
-          req.query.RelayState = relay.toString();
+        if (successRedirect) {
+          if (typeof req.query.representingMode === 'string') {
+            successRedirect.searchParams.set('representingMode', req.query.representingMode);
+          }
+          const distinctFailureRedirect = failureRedirect?.toString() === successRedirect.toString() ? undefined : failureRedirect;
+          req.query.RelayState = serializeRelayStateRedirects(successRedirect, distinctFailureRedirect);
         }
         next();
       },
@@ -282,10 +281,11 @@ class App {
         next();
       },
       (req, res) => {
-        if (req.session?.returnTo) {
-          req.query.RelayState = req.session.returnTo;
-        } else if (req.query.successRedirect) {
-          req.query.RelayState = req.query.successRedirect;
+        const relayState = req.session?.returnTo ?? req.query.successRedirect;
+        const { successRedirect, failureRedirect } = getRelayStateRedirects(relayState, ORIGIN);
+        if (successRedirect) {
+          const distinctFailureRedirect = failureRedirect?.toString() === successRedirect.toString() ? undefined : failureRedirect;
+          req.query.RelayState = serializeRelayStateRedirects(successRedirect, distinctFailureRedirect);
         }
 
         if (!req.user || !req.user.nameID || !req.user.nameIDFormat) {
@@ -323,16 +323,24 @@ class App {
       logger.info('SAML logout callback received', { query: req.query, body: req.body, user: req.user });
       req.logout(err => {
         if (err) return res.status(500).send(err);
-        let successRedirect: URL = new URL(SAML_LOGOUT_REDIRECT ?? '');
+        const configuredLogoutRedirect = getAllowedRedirectUrl(SAML_LOGOUT_REDIRECT, ORIGIN);
+        if (!configuredLogoutRedirect) {
+          logger.error('SAML_LOGOUT_REDIRECT must use the configured ORIGIN');
+          return res.status(500).send('Invalid logout redirect configuration');
+        }
+
+        let successRedirect = configuredLogoutRedirect;
         let failureRedirect: URL | undefined;
         const urls = req?.body?.RelayState?.split(',') ?? [];
 
         if (urls.length !== 0) {
-          if (isValidUrl(urls[0])) {
-            successRedirect = new URL(urls[0]);
+          const requestedSuccessRedirect = getAllowedRedirectUrl(urls[0], ORIGIN);
+          const requestedFailureRedirect = getAllowedRedirectUrl(urls[1], ORIGIN);
+          if (requestedSuccessRedirect) {
+            successRedirect = requestedSuccessRedirect;
           }
-          if (isValidUrl(urls[1])) {
-            failureRedirect = new URL(urls[1]);
+          if (requestedFailureRedirect) {
+            failureRedirect = requestedFailureRedirect;
           } else {
             failureRedirect = successRedirect;
           }
@@ -357,20 +365,9 @@ class App {
     });
 
     this.app.post(`${BASE_URL_PREFIX}/saml/login/callback`, samlLimiter, bodyParser.urlencoded({ extended: false }), (req, res, next) => {
-      let successRedirect: URL | undefined, failureRedirect: URL | undefined;
+      const { successRedirect, failureRedirect } = getRelayStateRedirects(req?.body?.RelayState, ORIGIN);
 
-      const urls = req?.body?.RelayState.split(',');
-
-      if (isValidUrl(urls[0])) {
-        successRedirect = new URL(urls[0]);
-      }
-      if (isValidUrl(urls[1])) {
-        failureRedirect = new URL(urls[1]);
-      } else {
-        failureRedirect = successRedirect;
-      }
-
-      if (!failureRedirect) {
+      if (!successRedirect || !failureRedirect) {
         res.status(400).send('Missing or invalid RelayState');
         return;
       }

--- a/backend/src/auth/saml-security.test.ts
+++ b/backend/src/auth/saml-security.test.ts
@@ -1,0 +1,62 @@
+import {
+  getAllowedRedirectUrl,
+  getRelayStateRedirects,
+  getSamlSecurityOptions,
+  getSessionCookieOptions,
+  serializeRelayStateRedirects,
+} from './saml-security';
+
+const APP_ORIGIN = 'https://minasidor.example.se';
+
+describe('SAML security configuration', () => {
+  it('requires signed assertions, audience validation, timestamps and correlated responses', () => {
+    expect(getSamlSecurityOptions('business-center')).toEqual({
+      audience: 'business-center',
+      wantAssertionsSigned: true,
+      wantAuthnResponseSigned: false,
+      acceptedClockSkewMs: 5_000,
+      validateInResponseTo: 'always',
+      requestIdExpirationPeriodMs: 10 * 60 * 1000,
+    });
+  });
+
+  it('uses browser session cookie protections without requiring the cookie on the SAML POST callback', () => {
+    expect(getSessionCookieOptions(true, false)).toEqual({
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: true,
+    });
+    expect(getSessionCookieOptions(false, false).secure).toBe(false);
+  });
+});
+
+describe('SAML redirects', () => {
+  it('accepts paths on the configured application origin', () => {
+    expect(getAllowedRedirectUrl(`${APP_ORIGIN}/sv/oversikt?mode=private`, APP_ORIGIN)?.toString()).toBe(`${APP_ORIGIN}/sv/oversikt?mode=private`);
+  });
+
+  it.each(['https://evil.example/phishing', 'https://minasidor.example.se@evil.example/phishing', 'javascript:alert(1)', '/relative-path'])(
+    'rejects an untrusted redirect: %s',
+    redirect => {
+      expect(getAllowedRedirectUrl(redirect, APP_ORIGIN)).toBeUndefined();
+    },
+  );
+
+  it('falls back to the safe success URL when a failure URL is not provided', () => {
+    const redirects = getRelayStateRedirects(`${APP_ORIGIN}/success`, APP_ORIGIN);
+
+    expect(redirects.successRedirect?.toString()).toBe(`${APP_ORIGIN}/success`);
+    expect(redirects.failureRedirect?.toString()).toBe(`${APP_ORIGIN}/success`);
+    if (!redirects.successRedirect) {
+      throw new Error('Expected the same-origin redirect to be accepted');
+    }
+    expect(serializeRelayStateRedirects(redirects.successRedirect)).toBe(`${APP_ORIGIN}/success`);
+  });
+
+  it('does not preserve an untrusted failure URL in RelayState', () => {
+    const redirects = getRelayStateRedirects(`${APP_ORIGIN}/success,https://evil.example/failure`, APP_ORIGIN);
+
+    expect(redirects.successRedirect?.toString()).toBe(`${APP_ORIGIN}/success`);
+    expect(redirects.failureRedirect?.toString()).toBe(`${APP_ORIGIN}/success`);
+  });
+});

--- a/backend/src/auth/saml-security.ts
+++ b/backend/src/auth/saml-security.ts
@@ -1,0 +1,46 @@
+import { ValidateInResponseTo } from '@node-saml/passport-saml';
+
+const SAML_REQUEST_ID_EXPIRATION_MS = 10 * 60 * 1000;
+
+export const getSamlSecurityOptions = (issuer: string) => ({
+  audience: issuer,
+  wantAssertionsSigned: true,
+  wantAuthnResponseSigned: false,
+  acceptedClockSkewMs: 5_000,
+  validateInResponseTo: ValidateInResponseTo.always,
+  requestIdExpirationPeriodMs: SAML_REQUEST_ID_EXPIRATION_MS,
+});
+
+export const getSessionCookieOptions = (isProduction: boolean, isTestEnvironment: boolean) => ({
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  secure: isProduction && !isTestEnvironment,
+});
+
+export const getAllowedRedirectUrl = (value: unknown, allowedOrigin: string | undefined): URL | undefined => {
+  if (typeof value !== 'string' || !allowedOrigin) {
+    return undefined;
+  }
+
+  try {
+    const redirectUrl = new URL(value);
+    const originUrl = new URL(allowedOrigin);
+    const usesHttp = redirectUrl.protocol === 'http:' || redirectUrl.protocol === 'https:';
+    const originUsesHttp = originUrl.protocol === 'http:' || originUrl.protocol === 'https:';
+
+    return usesHttp && originUsesHttp && redirectUrl.origin === originUrl.origin ? redirectUrl : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const getRelayStateRedirects = (relayState: unknown, allowedOrigin: string | undefined) => {
+  const [successValue, failureValue] = typeof relayState === 'string' ? relayState.split(',', 2) : [];
+  const successRedirect = getAllowedRedirectUrl(successValue, allowedOrigin);
+  const failureRedirect = getAllowedRedirectUrl(failureValue, allowedOrigin) ?? successRedirect;
+
+  return { successRedirect, failureRedirect };
+};
+
+export const serializeRelayStateRedirects = (successRedirect: URL, failureRedirect?: URL): string =>
+  failureRedirect ? `${successRedirect.toString()},${failureRedirect.toString()}` : successRedirect.toString();

--- a/backend/src/utils/util.ts
+++ b/backend/src/utils/util.ts
@@ -39,13 +39,3 @@ export const formatOrgNr = (orgNr: string, format: OrgNumberFormat = OrgNumberFo
   }
   return null;
 };
-
-export const isValidUrl = (string: string) => {
-  let url;
-  try {
-    url = new URL(string);
-  } catch (_) {
-    return false;
-  }
-  return url.protocol === 'http:' || url.protocol === 'https:';
-};

--- a/backend/src/utils/validateEnv.ts
+++ b/backend/src/utils/validateEnv.ts
@@ -20,6 +20,7 @@ const validateEnv = () => {
     CLIENT_SECRET: str(),
     PORT: port(),
     BASE_URL_PREFIX: str(),
+    ORIGIN: url(),
     SAML_CALLBACK_URL: url(),
     SAML_FAILURE_REDIRECT: url(),
     SAML_ENTRY_SSO: url(),
@@ -27,10 +28,10 @@ const validateEnv = () => {
     SAML_IDP_PUBLIC_CERT: str(),
     SAML_PRIVATE_KEY: str(),
     SAML_PUBLIC_KEY: str(),
-    SAML_LOGOUT_URL: str(),
-    SAML_LOGOUT_CALLBACK_URL: str(),
-    SAML_LOGOUT_REDIRECT: str(),
-    SAML_SUCCESS_REDIRECT: str(),
+    SAML_LOGOUT_URL: url(),
+    SAML_LOGOUT_CALLBACK_URL: url(),
+    SAML_LOGOUT_REDIRECT: url(),
+    SAML_SUCCESS_REDIRECT: url(),
     FEEDBACK_EMAIL: emails(),
   });
 };


### PR DESCRIPTION
## Varför

SAML-konfigurationen stängde av audience- och tidsvalidering, korrelerade inte svar mot utfärdade AuthnRequests och accepterade användarstyrda redirect-URL:er från valfri HTTP(S)-origin. Sessionscookien använde dessutom `SameSite=None` trots att flödet redan transporterar nödvändigt state via RelayState.

## Ändring och nytta

- Kräver signerade assertions; top-level-svarssignatur förblir valfri för IdP-kompatibilitet.
- Validerar Audience mot service provider-issuer.
- Återaktiverar `NotBefore`/`NotOnOrAfter` med 5 sekunders klocktolerans.
- Kräver `InResponseTo` och begränsar request-id-livslängden till 10 minuter.
- Sätter sessionscookie till `HttpOnly`, `SameSite=Lax` och `Secure` i produktion.
- Tillåter login/logout-redirects endast till exakt konfigurerad `ORIGIN` och tar bort den generiska, svagare URL-kontrollen.
- Validerar SAML- och originmiljövariabler som URL:er vid start.
- Samlar säkerhetspolicyn i `auth/saml-security.ts` och skyddar den med 9 tester, inklusive origin-confusion/open-redirect-fall.

Fördelen är skydd mot replay/unsolicited responses, fel audience, utgångna assertions, osignerade assertions, open redirect och onödigt cross-site cookie-läckage.

## Verifiering

- Hela backendsviten: 108/108 tester.
- `yarn type-check`, `yarn lint`, `yarn knip`, `yarn build`.

## Måste verifieras före merge

Denna PR ska stanna som draft tills följande har testats mot riktig IdP i staging:

1. IdP:n signerar assertionen och sätter Audience till nuvarande `SAML_ISSUER`.
2. Login, felredirect, representing mode och logout fungerar med `SameSite=Lax`.
3. IdP-svaret innehåller korrekt `InResponseTo` och kommer tillbaka inom 10 minuter.
4. Om backend kör flera repliker måste request-id-cachen delas eller trafiken vara sticky. Node-SAMLs standardcache är processlokal; utan detta kan en callback på en annan replika nekas. Repokonfigurationen anger inte replica-/load-balancer-topologin, så detta kan inte bevisas lokalt.

## Risk och återställning

Högre kompatibilitetsrisk men avsedd säkerhetshärdning. Vid stagingproblem bör orsaken rättas i IdP/audience/cache-konfigurationen. En selektiv revert av `InResponseTo` kan användas som tidsbegränsad incidentåtgärd, men övriga valideringar och redirect-skydd bör behållas.
